### PR TITLE
Fix Kamal first-deploy image build and proxy health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,13 +21,12 @@ FROM base as build
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential curl git libpq-dev libvips node-gyp pkg-config python-is-python3
 
-# Install JavaScript dependencies
+# Install JavaScript dependencies (Yarn 4 via Corepack + packageManager in package.json)
 ARG NODE_VERSION=20.14.0
-ARG YARN_VERSION=1.22.22
 ENV PATH=/usr/local/node/bin:$PATH
 RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
     /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
-    npm install -g yarn@$YARN_VERSION && \
+    corepack enable && \
     rm -rf /tmp/node-build-master
 
 # Install application gems
@@ -36,8 +35,9 @@ RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
     bundle exec bootsnap precompile --gemfile
 
-# Install node modules
-COPY package.json yarn.lock ./
+# Install node modules (yarnPath in .yarnrc.yml needs the committed Yarn 4 binary)
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY .yarn/releases .yarn/releases
 RUN yarn install --frozen-lockfile
 
 # Copy application code

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,10 +48,15 @@ Rails.application.configure do
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
-  # config.assume_ssl = true
+  config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
+
+  # Skip http-to-https redirect for the default health check endpoint.
+  # kamal-proxy probes /up over plain HTTP on the container network; a redirect to HTTPS
+  # makes the proxy retry with TLS against Puma and fail the deploy health check.
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new($stdout)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,5 +101,7 @@ Rails.application.configure do
   # not set outside that verification window.
   config.hosts += ENV["ADDITIONAL_ALLOWED_HOSTS"].split(",").map(&:strip) if ENV["ADDITIONAL_ALLOWED_HOSTS"].present?
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  # kamal-proxy probes /up with the container id as Host (e.g. abc123:3000), which
+  # would otherwise be rejected by config.hosts and fail the deploy health check.
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
## Summary
- Update the Dockerfile for Yarn 4 (Corepack + committed yarn binary) so Kamal image builds succeed after the frontend toolchain upgrade
- Exclude `/up` from Rails host authorization and `force_ssl` redirects so kamal-proxy health checks can reach Puma over plain HTTP on the container network
- Enable `assume_ssl` behind kamal-proxy’s TLS termination

These changes were required to complete the first Linode/Kamal deploy for `jamesebentier.com` (now live at `https://jamesebentier.com`).

## Test plan
- [x] `bundle exec kamal deploy` succeeds against the Linode host
- [x] `https://jamesebentier.com/up` returns HTTP 200
- [x] `https://jamesebentier.com/` returns HTTP 200 with the homepage
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)