### PR TITLE
Fix RAILS_MASTER_KEY resolution in Kamal secrets for CI

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -10,7 +10,7 @@
 KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
 
 # Rails master key, used to decrypt config/credentials.yml.enc at boot.
-RAILS_MASTER_KEY=$(cat config/master.key)
+RAILS_MASTER_KEY=${RAILS_MASTER_KEY:-$(cat config/master.key 2>/dev/null)}
 
 # Postgres accessory credentials (POSTGRES_USER/POSTGRES_DB are set as env.clear in
 # accessories.postgres — not secret — but the password is).


### PR DESCRIPTION
## Problem

The automated Kamal deploy (introduced in #1174) failed on the first run with:

```
ArgumentError: Missing `secret_key_base` for 'production' environment
```

Root cause: `.kamal/secrets` resolved `RAILS_MASTER_KEY` via `$(cat config/master.key)`. That file is gitignored and absent in CI, so the substitution returned an empty string — the container booted with no master key and couldn't decrypt credentials.

## Fix

```sh
# before
RAILS_MASTER_KEY=$(cat config/master.key)

# after
RAILS_MASTER_KEY=${RAILS_MASTER_KEY:-$(cat config/master.key 2>/dev/null)}
```

When `RAILS_MASTER_KEY` is already set in the environment (as it is in CI via the GitHub secret), the env var wins. When it's not set (local dev), it falls back to reading `config/master.key` as before.

## Test plan

- [ ] CI passes on this branch
- [ ] After merge, the next green `main` build triggers a successful Kamal deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)