### PR TITLE
Fix RAILS_MASTER_KEY resolution in .kamal/secrets (dotenv compat)

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -10,7 +10,7 @@
 KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
 
 # Rails master key, used to decrypt config/credentials.yml.enc at boot.
-RAILS_MASTER_KEY=${RAILS_MASTER_KEY:-$(cat config/master.key 2>/dev/null)}
+RAILS_MASTER_KEY=$(printenv RAILS_MASTER_KEY || cat config/master.key)
 
 # Postgres accessory credentials (POSTGRES_USER/POSTGRES_DB are set as env.clear in
 # accessories.postgres — not secret — but the password is).


### PR DESCRIPTION
## Problem

The automated Kamal deploy failed with:

```
ArgumentError: key must be 16 bytes
```

The previous fix used bash parameter expansion syntax:

```sh
RAILS_MASTER_KEY=${RAILS_MASTER_KEY:-$(cat config/master.key 2>/dev/null)}
```

This looks correct in bash, but Kamal parses `.kamal/secrets` using the `dotenv` gem — not bash. Dotenv's variable substitution treats the entire string `RAILS_MASTER_KEY:-$(cat config/master.key 2>/dev/null)` as the variable name, finds nothing in the environment, and returns empty. The `$(cat config/master.key)` command substitution then runs but finds no file in CI, so `RAILS_MASTER_KEY` is set to an empty string in the container. An empty key → Rails tries to use 0 bytes as an AES-128 key → `key must be 16 bytes`.

## Fix

```sh
RAILS_MASTER_KEY=$(printenv RAILS_MASTER_KEY || cat config/master.key)
```

`$(...)` command substitution is what Kamal/dotenv does support. `printenv` inherits the CI runner's environment (where `RAILS_MASTER_KEY` is set via the workflow `env:` block) and exits 0 on success. If not set (local dev), it exits 1 and `||` falls through to reading `config/master.key` as before.

## Test plan

- [ ] CI passes on this branch
- [ ] After merge, the next green `main` build triggers a successful Kamal deploy with the container booting cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)