### PR TITLE
Add 2026 redesign design doc + Phase-1 issue drafts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      non_docs: ${{ steps.filter.outputs.non_docs }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            non_docs:
+              - '!docs/**'
+
   danger:
     name: Danger
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.non_docs == 'true'
     steps:
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
@@ -31,6 +48,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.non_docs == 'true'
     steps:
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
@@ -42,6 +61,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.non_docs == 'true'
     services:
       postgres:
         image: postgres:16-alpine
@@ -77,11 +98,19 @@ jobs:
   ci-gate:
     name: ci-gate
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [changes, lint, test]
     if: always()
     steps:
       - name: Check required jobs
         run: |
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "Change detection failed (changes=${{ needs.changes.result }}); failing closed."
+            exit 1
+          fi
+          if [ "${{ needs.changes.outputs.non_docs }}" != "true" ]; then
+            echo "Docs-only change detected; no required CI jobs needed. Reporting success."
+            exit 0
+          fi
           if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ]; then
             echo "Required CI jobs failed (lint=${{ needs.lint.result }}, test=${{ needs.test.result }})"
             exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,11 +15,45 @@ permissions:
   packages: write
 
 jobs:
+  changes:
+    name: Detect docs-only change
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - name: Inspect triggering commit for docs-only change
+        id: filter
+        uses: actions/github-script@v9
+        with:
+          script: |
+            let docsOnly = false;
+            try {
+              const sha = context.payload.workflow_run.head_sha;
+              const { data: commit } = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: sha,
+              });
+              const paths = (commit.files || []).map((f) => f.filename);
+              docsOnly = paths.length > 0 && paths.every((p) => p.startsWith('docs/'));
+              core.info(`Triggering commit: ${sha}`);
+              core.info(`Changed files (${paths.length}): ${paths.join(', ') || '(none reported)'}`);
+              core.info(`docs_only=${docsOnly}`);
+            } catch (e) {
+              // Fail open: if we cannot confidently determine the changeset,
+              // fall through to a normal deploy rather than silently skipping it.
+              core.warning(`Could not determine changed files (${e.message}); proceeding with deploy.`);
+              docsOnly = false;
+            }
+            core.setOutput('docs_only', docsOnly ? 'true' : 'false');
+
   deploy:
     name: Kamal Deploy
     runs-on: ubuntu-latest
+    needs: changes
     timeout-minutes: 30
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success' && needs.changes.outputs.docs_only != 'true'
 
     steps:
       - uses: actions/checkout@v7

--- a/docs/design/redesign-2026.md
+++ b/docs/design/redesign-2026.md
@@ -1,0 +1,346 @@
+# jamesebentier.com — Redesign Design Doc (2026)
+
+> **Status:** Draft for review · **Owner:** James Ebentier · **Created:** 2026-07-18
+>
+> This is the consolidated design reference for the site redesign. It captures the
+> positioning, visual direction, information architecture, and a phased build plan.
+> Individual pieces become ADLC issues (spec-before-code) driven by the orchestrator.
+> This doc is the *why* and the *shape*; per-issue specs are the *how*.
+
+---
+
+## 1. Goals
+
+Re-purpose the personal site into a stronger launching point for **fractional
+architect / CTO** work — guiding a company's technical direction temporarily or in
+a niche, through mentorship and contract work — **without** a hard consulting pitch.
+The site should read as *nerdy but smart and professional*: an engineer who clearly
+builds things for fun, and whose thinking is worth paying for.
+
+Three initiatives layered on the current (solid) Rails base:
+
+1. **Visual / brand refresh** — a sleek, modern, hacker-esque but approachable UI.
+2. **Content consolidation** — projects + writing presented well; Medium handled via
+   syndication so there's a single place to write.
+3. **AI Lab identity** — this domain becomes the central login authority (OIDC/OAuth2
+   provider) for a set of AI experiment projects.
+
+### Non-goals
+- No hard "hire me" / services-with-pricing page. The signal stays subtle (proof over pitch).
+- No framework change. Rails 8 + Hotwire + Tailwind 4 + DaisyUI stays.
+- No migration of legacy identity (there is none today — greenfield auth).
+
+---
+
+## 2. Positioning
+
+**Fractional architect / CTO.** A real, understood category — no explanation required.
+The soft-sell mechanic is *demonstration, not solicitation*: sharp writing, real shipped
+projects, visible mentorship, and the AI Lab as living proof of competence. One
+understated CTA ("Work with me" / "Let's talk"), no banners.
+
+**Positioning line:**
+> "I help engineers get their systems right — a fraction of the time, all of the leverage."
+
+Note the deliberate framing: *engineers* (not startups) and *systems* (not architecture)
+keeps the emphasis on craft, mentorship, and helping people grow — the true passion —
+while "a fraction of the time" quietly carries the fractional-architect signal.
+
+---
+
+## 3. Visual direction — "Refined terminal, warmed up"
+
+Dark-first and minimal (restraint in the spirit of philipwalton.com), softened toward
+approachable (warmth in the spirit of taniarascia.com), with a retained hacker/scrappy
+edge.
+
+- **Mode:** dark-first. Keep the existing light theme for the print/resume path.
+- **Terminal theme picker (playful):** let the viewer pick a theme from a small,
+  terminal-style switcher. Defaults are **light** and **dark**; additionally offer a
+  handful of beloved developer color schemes (candidates: Dracula, Solarized Dark/Light,
+  Gruvbox, Nord, Monokai, Tokyo Night, Catppuccin). Persist the choice (localStorage /
+  cookie). Implemented as DaisyUI themes + a Stimulus controller. This is a personality
+  moment — the switcher itself should feel like a tiny terminal.
+- **Palette:** retire the multi-color accent hero (green/purple/orange/pink/yellow).
+  Move to a disciplined base — near-black canvas, soft off-white text — plus **one
+  signature accent: amber `#fab73a`** (already in use), applied consistently to links,
+  focus states, and CTAs.
+- **Typography:** **Commit Mono** is the signature typeface — used for headings, nav,
+  metadata, labels, code, and all "system" cues — paired with a clean sans (Montserrat,
+  or revisit) for long-form body so Deep Dives stay comfortable. Commit Mono is
+  free/open, neutral-but-characterful, and [its own site](https://commitmono.com/) is a
+  direct design touchstone for us (see the keyboard command layer below).
+- **Type scale:** base **18px**, **Major Third (1.250)** → 18 · 23 · 28 · 35 · 44 · 55.
+  Editorial enough for Deep Dives, punchy headings. Adjustable; exact `rem` tokens are
+  spec'd in the design-system issue.
+- **Components (DaisyUI + a thin custom layer):** section wrapper, project card, post
+  card, tag/status pill, reusable CTA. Rounded cards, comfortable spacing.
+- **Motion:** restrained — fade/slide on scroll, hover lift on cards — via a Stimulus
+  controller.
+- **Personality:** carried by monospace/terminal touches and opinionated post titles.
+  No forced logo gimmick. (Optional, low-priority: a tasteful `½` / fraction-bar glyph
+  in the logo lockup as a subtle nod to "fractional" — not a lead element.)
+
+### Signature interaction — the site as a terminal
+Inspired directly by commitmono.com's keyboard-driven UI. The site is fully driveable
+from the keyboard via a **command layer** — this is the personality centerpiece and it
+unifies theming, navigation, and analytics into one coherent nerdy-but-polished idea.
+
+- **Command palette / console** — `Cmd/Ctrl-K` (and `` ` ``/`:`) opens a real terminal-style
+  overlay. Type commands, don't just click.
+- **Single-key shortcuts** — e.g. `t` cycle theme, `g h` go home, `g w` writing, `g p`
+  projects, `g l` lab, `/` focus search, `?` toggle a keyboard-guide overlay (à la
+  Commit Mono's guide), `Esc` dismiss.
+- **Queryable everything** — the console can navigate, switch theme, *and query the
+  site's own first-party analytics* (see §6.4) — e.g. `stats views --last 7d`,
+  `top posts`. Metrics stay on our infrastructure and become interactive, not hidden.
+- **Progressive enhancement + a11y** — everything works without the keyboard layer;
+  shortcuts never trap focus, respect `prefers-reduced-motion`, and are fully
+  screen-reader friendly. Built as a Stimulus controller.
+
+### Design references distilled
+- **taniarascia.com** — warmth, a content taxonomy (Blog/Notes/Deep Dives/Projects),
+  a human note, personality artifacts, newsletter + RSS.
+- **daverupert.com** — personality through specific/opinionated titles; tags; an
+  "Active Projects" grid; indie-web social presence.
+- **philipwalton.com** — authority through restraint; excerpts under titles; the
+  minimalism *is* the flex.
+- **jareddillard.com** — hobbies-as-tools; projects are useful things that reveal the
+  person (our AI Lab is this).
+
+Shared DNA to adopt: content-first minimalism; **writing feed as the homepage**; a crisp
+one-line identity statement; plain text nav; tags + dates + excerpts; and **POSSE**
+(Publish on your Own Site, Syndicate Elsewhere) — which is exactly the Medium strategy.
+
+---
+
+## 4. Information architecture
+
+```
+/            Hero (positioning) → Featured projects → Latest writing → understated CTA
+/writing     Blog index (canonical home for posts); filter by kind (Notes / Deep Dives)
+/writing/:slug
+/projects    Grid, filterable by status (Pre-Launch / Beta / Live), triple-link cards
+/projects/:slug
+/lab         AI Lab directory — what it is + list of experiments (public shell in P1)
+/lab/*       OIDC-protected experiments (Phase 2)
+/about       The fractional-architect story + mentorship — carries the soft signal
+/resume      Keep as-is (print-friendly, light theme)
+```
+
+- **Clean refresh — no `/blog` → `/writing` redirect.** This is a deliberate reset, not a
+  migration; treat it as a new front door.
+- Home is the front door for **writing** (per the shared DNA of all four references).
+
+---
+
+## 5. Content model
+
+Stays file-backed markdown + DB metadata (it works). Additions:
+
+### Newsletter (aspirational)
+Add a newsletter signup (footer + a tasteful home placement). **Not launched immediately**
+— it's a demand signal: collect addresses now, and if enough interest accumulates, stand up
+a real newsletter later. Implementation: capture emails to our own DB (a `Subscriber` model)
+rather than committing to a provider up front, so there's no vendor lock-in before it's worth
+it. Confirm opt-in (double opt-in) and GDPR-compliant storage (see §8, we're Berlin-based).
+
+### `Post`
+- `kind` — enum: `note` | `deep_dive`. **All existing posts are Deep Dives**; Notes
+  start later. Guidelines below.
+- `tags` — already present; surface in UI.
+- `excerpt` — one/two-line summary shown under titles in the feed.
+- `reading_time` — derived from content.
+- `featured` — boolean, drives home-page selection.
+- `medium_url` (and optional `canonical_url`) — for the "Also on Medium" link.
+
+### Note vs. Deep Dive — editorial guidelines
+So both writer and readers share expectations:
+
+| | **Note** | **Deep Dive** |
+|---|---|---|
+| Length | Short (~< 500 words) | Long-form (~1,000+ words) |
+| Purpose | A single thought, reaction, TIL, or link + commentary | A worked-through system, argument, or lesson that teaches a reusable mental model |
+| Cadence | Frequent, low ceremony | Infrequent, high polish |
+| Artifacts | Optional | Usually code, diagrams, or worked examples |
+| Role | Keeps the site alive, shows personality | The credibility engine for fractional work |
+
+**Heuristic:** *If it teaches a reusable mental model or walks through a system, it's a
+Deep Dive. If it's a thought, reaction, or TIL, it's a Note.* When in doubt, it's a Note —
+Notes can graduate into Deep Dives.
+
+### `Project`
+- `status` — already present (`Pre-Launch` / `Beta` / `Live`); surface as a pill.
+- Triple-link fields — **read** (article/details) → **demo** (live URL) → **source**
+  (repo). `url` exists; add the others as optional.
+- `featured` — boolean, drives home-page selection.
+
+---
+
+## 6. The three hard problems
+
+### 6.1 Identity — AI Lab central login authority
+**Decision: self-hosted OIDC via Doorkeeper.** This domain becomes an OAuth2 /
+OpenID Connect **provider**; each AI Lab project is an OIDC client (relying party)
+that trusts `jamesebentier.com` as its IdP.
+
+- Gems: `doorkeeper` + `doorkeeper-openid_connect`.
+- A `User` model + auth (registration, login, session, password reset). MFA later.
+- Branded, on-domain **login + consent** screens — the visible "central authority" moment.
+- Flow: Authorization Code + **PKCE** for each client.
+- Needs an RSA signing key for OIDC ID tokens — managed via **Kamal secrets**.
+- New subsystem: **`identity`** in `docs/architecture`, beside `content-domain`.
+- Security-sensitive: own spec, careful review pass, rate limiting on auth endpoints,
+  token/key rotation, audit logging.
+- **Domain strategy — subdomains, not paths.** Each experiment gets its own subdomain
+  (e.g. `lab.jamesebentier.com`, `<experiment>.jamesebentier.com`) so experiments can be
+  deployed to different machines independently. The IdP lives on the apex/`accounts`
+  subdomain. Implication: OIDC redirect URIs and cookie scope are per-subdomain (no shared
+  session cookie across subdomains — auth flows through OIDC, which is the correct pattern
+  anyway). Plan a wildcard TLS cert (`*.jamesebentier.com`).
+
+*Alternatives considered and declined:* self-hosted Keycloak/Ory (heavier ops); managed
+IdP — WorkOS/Auth0/Clerk/Logto (fast, but dilutes the "my domain is the authority"
+narrative and adds a vendor).
+
+### 6.2 Medium — content syndication
+**Decision: this site is canonical; syndicate *to* Medium (POSSE).**
+
+Reality: Medium's public **posting API is deprecated** (no new integration tokens since
+~2023), so true API-driven "publish everywhere" isn't available. Workflow instead:
+
+1. Write markdown here; publish (site = source of truth / canonical).
+2. Use Medium's **"Import a story"** tool with your post URL — Medium creates a copy that
+   auto-sets `rel=canonical` back to jamesebentier.com (SEO/traffic accrues to your domain).
+3. Store the resulting `medium_url` on the `Post` and render an "Also on Medium" link.
+
+Document this as a repeatable **runbook** (`docs/ops/medium-syndication.md`).
+
+### 6.3 Visual redesign
+Design-token + component pass, not a rewrite. Lives in `application.tailwind.css` theme
+tokens + `web-presentation` views/components. Low-risk; each piece reviewable in one
+sitting (fits the strategic-priorities size/ambiguity envelope).
+
+### 6.4 Bardic Labs — the AI Lab, and its rating mechanic
+**Name: Bardic Labs** (tabletop-RPG inspired). In tabletop, the **bard** is the support /
+mentor class, and **Bardic Inspiration** is the mechanic where the bard hands an ally a die
+to add to *their* roll — you make everyone around you succeed better. That's a bullseye for
+the brand: mentorship, growing the community, a fractional architect who levels up the team.
+It still ties to the dice: Bardic Inspiration *is* a bonus die.
+
+Clearance (as of 2026-07-18): no company trades as "Bardic Labs"; no USPTO `BARDIC` mark in
+software/consulting classes (only an unrelated textiles registration); the nearest name,
+Bardic Systems, is education-sector consulting in a distinct market. Caveats: "Bardic-" is a
+mildly crowded *prefix* (be deliberate about SEO/identity), and there's a faint, fading
+"Google Bard" echo in an AI context.
+
+**Hosting: subdomain-first.** Bardic Labs launches at **`bardic-labs.jamesebentier.com`** —
+a subdomain of the personal site, no separate domain required. Registering `bardiclabs.com`
+is therefore *optional defensive insurance*, not a technical dependency: cheap (~$12/yr) to
+reserve and 301-redirect to the subdomain if the brand might ever go standalone; safe to
+defer if it stays a personal sub-experiment. (`.dev` is a natural fallback.) Domain ≠
+trademark — no TM action warranted for a personal lab.
+
+- **Rating mechanic (unchanged):** every experiment gets a **d20 rating, Nat 1 → Nat 20**,
+  by how successful it turned out. Deliberately humble — *every idea is a roll of the dice*;
+  most land mid-scale, some crit, some flop. Reinforces the authentic, build-in-public ethos.
+- **Rating model:** owner-assigned score to start; **optionally let visitors rank** each
+  experiment too (community engagement → ties to the mentorship/community goal). Owner vs.
+  visitor scoring — and whether they're shown side by side — is an open detail (§8).
+- Surfaces on the `/lab` directory as a d20 badge per experiment; sortable by roll.
+- Fits the terminal theme (`roll`-flavored commands are a fun future touch, e.g.
+  `lab --sort roll`). Bardic Inspiration could even theme the newsletter/mentorship touch.
+
+### 6.5 Analytics — first-party, and the AI Lab's first experiment
+**Decision: remove Google Analytics and Metricool; build our own first-party metrics.**
+No visitor data leaves our infrastructure. This is framed as **the AI Lab's inaugural
+experiment** — dogfooding the "build it myself" ethos.
+
+- **Collection:** lightweight first-party event capture (page views, referrers, basic
+  UTM) stored in our own Postgres — privacy-respecting, no third-party beacons. Cookieless
+  where possible (eases the GDPR/consent story; see §8).
+- **Queryable via the terminal.** The killer tie-in: metrics are surfaced through the
+  site's command layer (§3) — `stats views --last 7d`, `top posts`, `referrers`. Public
+  vs. owner-only query scopes TBD (some stats could even be public — "build in public").
+- **Removes** the GA (`G-TWP4CV64DK`) and Metricool snippets from the layout.
+- Likely its own small subsystem (`analytics`) once it grows past a single table.
+
+---
+
+## 7. Phased roadmap (ADLC-sized issues)
+
+### Phase 1 — Visual refresh + content (ship first)
+1. **Design system pass** — Tailwind theme tokens (palette, type scale, mono font),
+   DaisyUI theme config, shared components (card / pill / section / CTA), motion Stimulus
+   controller.
+2. **Hero + home redesign** — positioning copy, featured projects, latest writing, subtle CTA.
+3. **Projects page redesign** — card grid, status filter/pill, triple-link cards,
+   coming-soon/empty states.
+4. **Writing redesign + content types** — `Post.kind` (Notes / Deep Dives), index + filter,
+   article typography polish, reading time, tags, excerpts.
+5. **About page** — fractional-architect narrative + mentorship (soft consulting signal).
+6. **Medium syndication workflow** — `medium_url` field, "Also on Medium" link, runbook doc.
+7. **Newsletter signup (aspirational)** — `Subscriber` model, footer + home signup, double
+   opt-in, GDPR-compliant storage. No provider/sending yet — demand signal only.
+8. **SEO / meta polish** — per-page OG images, JSON-LD `Person` / `Article` structured data.
+9. **Legal compliance** — **Impressum + privacy policy** (legally required for a
+   Berlin-based site; see §8). Dedicated ticket, not folded into another issue.
+10. **Keyboard command layer (signature)** — command palette + single-key shortcuts +
+    keyboard-guide overlay, driving nav and theme switching. Extensible so §6.4 metrics
+    queries plug in. Depends on the design-system pass (#1).
+11. **First-party analytics** — remove GA + Metricool; add cookieless first-party event
+    capture to Postgres; expose queries through the command layer. (AI Lab experiment #1.)
+12. **Build-in-public** — a `/changelog` page + a site version in the footer + a
+    "Rebuilding this site" **Notes series** documenting the refresh publicly.
+13. **Contact CTA** — "Work with me" as a simple `mailto:` link for now; structured so it
+    can grow into a form/booking flow later without a redesign.
+
+### Phase 2 — AI Lab identity (login authority)
+8. **Doorkeeper OIDC provider** — gems, `User` model + auth, signing key via Kamal secrets.
+9. **Login / consent UI** — branded, on-domain.
+10. **`/lab` landing (Bardic Labs)** — public directory of the lab + experiments, each with
+    a d20 rating badge (Nat 1–Nat 20), sortable by roll. Visitor-ranking is a follow-on.
+11. **First OIDC client integration** — wire one lab app end-to-end (auth code + PKCE).
+12. **Ops hardening** — key/token rotation, rate limiting, audit logging, secrets management.
+
+---
+
+## 8. Open questions / to refine later
+- **Bardic Labs rating scope** — owner-only vs. visitor ranking (and whether both are
+  shown); if visitors rank, decide anti-abuse (auth-gated? one-vote?). Name is decided.
+- **Optional:** reserve `bardiclabs.com` (or `.dev`) as defensive insurance + redirect to
+  the subdomain. Not required — Bardic Labs is subdomain-first (§6.4).
+- **Final social links list** — include all (GitHub, LinkedIn, Mastodon, Bluesky, etc.);
+  James provides the full set before that section is built.
+- **GDPR/consent specifics** — cookieless first-party analytics should minimize the need
+  for a consent banner; confirm with the privacy-policy/Impressum work. German **TTDSG** +
+  **GDPR** apply.
+- **Hero copy** beyond the positioning line.
+- **Terminal theme picker** — final list of bundled themes.
+- **Owner-only vs public** scopes for terminal metrics queries.
+- **Newsletter provider** — deferred until demand justifies it (own-DB capture until then).
+
+---
+
+## 9. Decision log
+| Decision | Choice | Date |
+|---|---|---|
+| Identity architecture | Self-hosted OIDC via Doorkeeper | 2026-07-18 |
+| Medium strategy | Site canonical, syndicate to Medium (POSSE) | 2026-07-18 |
+| Consulting signal | Subtle — proof over pitch | 2026-07-18 |
+| Build sequence | Design & content first, then identity | 2026-07-18 |
+| Aesthetic | Refined terminal, warmed up | 2026-07-18 |
+| Content types | Notes + Deep Dives split | 2026-07-18 |
+| Positioning term | Fractional architect / CTO (not "fractal") | 2026-07-18 |
+| Positioning line | "I help engineers get their systems right…" | 2026-07-18 |
+| Signature typeface | Commit Mono (mono roles) + sans body | 2026-07-18 |
+| Type scale | 18px base, Major Third (1.250) | 2026-07-18 |
+| Theme picker | Playful terminal theme switcher (light/dark + dev schemes) | 2026-07-18 |
+| Keyboard UX | Full keyboard command layer / site-as-terminal | 2026-07-18 |
+| Newsletter | Aspirational; own-DB capture, launch on demand | 2026-07-18 |
+| Analytics | Drop GA + Metricool; first-party, terminal-queryable | 2026-07-18 |
+| AI Lab name | Bardic Labs (bard = mentor class), Nat 1–Nat 20 rating | 2026-07-18 |
+| AI Lab domains | Subdomains (multi-machine capable), not paths | 2026-07-18 |
+| Contact CTA | `mailto:` link for now, expandable later | 2026-07-18 |
+| `/blog` redirect | None — clean refresh, no redirect needed | 2026-07-18 |
+| Content backfill | All existing posts = Deep Dives | 2026-07-18 |

--- a/docs/design/redesign-phase1-issues.md
+++ b/docs/design/redesign-phase1-issues.md
@@ -1,0 +1,382 @@
+# Redesign — Phase 1 issue drafts
+
+> Draft issues for **Phase 1** of the [2026 redesign](./redesign-2026.md) (visual refresh +
+> content). Ready to create on GitHub once approved. Format mirrors the repo's existing
+> issue template (Parent → Design → Context → ADLC delivers → Manual ops → Done when →
+> Dependencies). All are `enhancement` unless noted.
+>
+> **Sequencing:** the design-system pass (P1.1) is the foundation and should merge first;
+> it unblocks the page redesigns and the keyboard layer. Everything else is largely
+> parallelizable. Suggested order: **P1.1 → (P1.2, P1.3, P1.4, P1.8 in parallel) →
+> remainder**. Each issue is scoped to stay reviewable in one sitting.
+
+```mermaid
+graph TD
+  E[Epic: Phase 1]
+  P1[P1.1 Design system]
+  P2[P1.2 Home]
+  P3[P1.3 Projects]
+  P4[P1.4 Writing + content types]
+  P5[P1.5 About + CTA]
+  P6[P1.6 Medium]
+  P7[P1.7 Newsletter]
+  P8[P1.8 Keyboard layer]
+  P9[P1.9 First-party analytics]
+  P10[P1.10 SEO/meta]
+  P11[P1.11 Legal]
+  P12[P1.12 Build-in-public]
+
+  P1 --> P2
+  P1 --> P3
+  P1 --> P4
+  P1 --> P8
+  P8 -.query.-> P9
+```
+
+---
+
+## EPIC — 2026 Site Redesign — Phase 1: visual refresh + content
+
+**Labels:** `enhancement`, `documentation`
+
+### Context
+Repurpose jamesebentier.com into a stronger, subtler launching point for fractional
+architect/CTO work — nerdy but professional. Phase 1 delivers the brand impact: a
+refined-terminal visual system, the page redesigns (home/projects/writing/about), the
+Notes vs Deep Dives content model, Medium syndication, an aspirational newsletter, the
+keyboard-driven command layer, first-party analytics (retiring GA/Metricool), SEO polish,
+legal compliance, and build-in-public plumbing. Phase 2 (Bardic Labs identity/OIDC) is
+tracked separately.
+
+Design: `docs/design/redesign-2026.md`
+
+### Children
+- P1.1 Design system pass — theme tokens, Commit Mono, components, theme picker
+- P1.2 Home / hero redesign
+- P1.3 Projects page redesign
+- P1.4 Writing redesign + Notes/Deep Dives content model
+- P1.5 About page + "Work with me" contact CTA
+- P1.6 Medium syndication (POSSE)
+- P1.7 Newsletter signup (aspirational)
+- P1.8 Keyboard command layer (site-as-terminal)
+- P1.9 First-party analytics + retire GA/Metricool
+- P1.10 SEO / meta / structured-data polish
+- P1.11 Legal: Impressum + privacy policy
+- P1.12 Build-in-public: /changelog + site version
+
+### Done when
+All twelve children are merged and the refreshed public site is live.
+
+---
+
+## P1.1 — Design system pass (refined-terminal visual foundation)
+
+**Labels:** `enhancement`
+
+### Parent
+Epic: 2026 Site Redesign — Phase 1. Design: `docs/design/redesign-2026.md` §3.
+
+### Context
+Establish the "refined terminal, warmed up" visual language as reusable tokens +
+components so every later page pulls from one source of truth. Dark-first, amber accent
+(`#fab73a`), Commit Mono for headings/metadata/code + a clean sans for body, 18px base with
+a Major-Third (1.250) scale. Includes the playful **terminal theme picker** (light/dark +
+dev color schemes).
+
+### ADLC delivers
+- Tailwind `@theme` tokens: palette, type scale, font families (Commit Mono + sans).
+- DaisyUI theme config for light, dark, and a curated set of developer schemes
+  (candidates: Dracula, Solarized, Gruvbox, Nord, Tokyo Night, Catppuccin).
+- Shared view components/partials: section wrapper, card, tag/status pill, CTA button.
+- Theme-picker Stimulus controller with persisted choice (localStorage/cookie).
+- A restrained motion controller (fade/slide, hover lift) respecting `prefers-reduced-motion`.
+
+### Done when
+- Tokens + components exist and are documented; the theme picker switches and persists.
+- At least one existing page is migrated to the new components as a proof.
+- Final bundled theme list and body-sans choice are recorded in the design doc.
+
+### Dependencies
+- **Blocks:** P1.2, P1.3, P1.4, P1.8.
+- **Open detail:** final theme list, body sans pairing (design doc §8).
+
+---
+
+## P1.2 — Home / hero redesign
+
+**Labels:** `enhancement`
+
+### Parent
+Epic: Phase 1. Design: `docs/design/redesign-2026.md` §2, §4.
+
+### Context
+Make the homepage the front door for *writing* (per the reference-site DNA): positioning +
+one-line identity statement, featured projects, latest writing, and one understated CTA.
+
+### ADLC delivers
+- New hero with the positioning line: "I help engineers get their systems right — a
+  fraction of the time, all of the leverage." (final hero copy drafted here).
+- Featured projects + latest writing sections (driven by `featured` flags from P1.3/P1.4).
+- Understated "Work with me" CTA (links to the mechanism from P1.5).
+
+### Done when
+- Home renders featured projects + latest posts using P1.1 components; CTA present; responsive.
+
+### Dependencies
+- **Blocked by:** P1.1. **Soft-depends:** P1.3/P1.4 for `featured` data (can stub first).
+
+---
+
+## P1.3 — Projects page redesign
+
+**Labels:** `enhancement`
+
+### Parent
+Epic: Phase 1. Design: `docs/design/redesign-2026.md` §4, §5.
+
+### Context
+Replace the current list with a card grid, status pills, and the triple-link pattern
+(read → demo → source) that signals "I ship."
+
+### ADLC delivers
+- `Project` additions: optional read/demo/source links + `featured` boolean (migration).
+- Card-grid index with status pill (Pre-Launch/Beta/Live), filter by status, empty/coming-soon states.
+- Updated project show page using P1.1 components.
+
+### Done when
+- Projects render as a filterable grid with triple-links + status; `featured` usable by home.
+
+### Dependencies
+- **Blocked by:** P1.1.
+
+---
+
+## P1.4 — Writing redesign + Notes/Deep Dives content model
+
+**Labels:** `enhancement`
+
+### Parent
+Epic: Phase 1. Design: `docs/design/redesign-2026.md` §4, §5.
+
+### Context
+Introduce the two-kind content model (Notes vs Deep Dives), refresh the index + article
+typography, and add tags/excerpt/reading-time. `/blog` becomes `/writing` (clean refresh,
+no redirect). All existing posts backfilled as Deep Dives.
+
+### ADLC delivers
+- `Post` additions: `kind` enum (`note`|`deep_dive`), `excerpt`, `reading_time` (derived),
+  `featured` boolean; surface `tags` (migration + backfill existing → `deep_dive`).
+- `/writing` index with kind filter; article page typography polish; tags + excerpts + dates.
+- Editorial guidelines page/section per design doc §5 (Note vs Deep Dive).
+
+### Done when
+- Posts have a kind; `/writing` filters by kind; articles show tags/excerpt/reading-time;
+  existing content reads as Deep Dives.
+
+### Dependencies
+- **Blocked by:** P1.1.
+
+---
+
+## P1.5 — About page + "Work with me" contact CTA
+
+**Labels:** `enhancement`
+
+### Parent
+Epic: Phase 1. Design: `docs/design/redesign-2026.md` §2, §4.
+
+### Context
+The `/about` page carries the soft fractional-architect + mentorship signal (proof over
+pitch). The CTA starts as a simple `mailto:` link, structured to grow into a form/booking
+flow later without a redesign.
+
+### ADLC delivers
+- `/about` narrative page (fractional architect + mentorship/community), using P1.1 components.
+- "Work with me" CTA component wired to `mailto:` for now; placement on home + about + footer.
+
+### Done when
+- `/about` live; CTA renders and opens email; easy to swap the CTA target later.
+
+### Dependencies
+- **Blocked by:** P1.1.
+
+---
+
+## P1.6 — Medium syndication (POSSE)
+
+**Labels:** `enhancement`, `documentation`
+
+### Parent
+Epic: Phase 1. Design: `docs/design/redesign-2026.md` §6.2.
+
+### Context
+Site is canonical; syndicate *to* Medium (their posting API is deprecated). Support an
+"Also on Medium" link and document the manual import-with-canonical runbook.
+
+### ADLC delivers
+- `Post` additions: `medium_url` (+ optional `canonical_url`) (migration); render
+  "Also on Medium" when present.
+- `docs/ops/medium-syndication.md` runbook (publish here → Medium "Import a story" →
+  canonical back to us → paste `medium_url`).
+
+### Done when
+- A post with `medium_url` shows the link; runbook exists and is followed once end-to-end.
+
+### Manual ops
+- Run the Medium import for a real post and confirm canonical points back to us.
+
+### Dependencies
+- **Soft-depends:** P1.4 (Post schema work) — coordinate migrations.
+
+---
+
+## P1.7 — Newsletter signup (aspirational, own-DB capture)
+
+**Labels:** `enhancement`
+
+### Parent
+Epic: Phase 1. Design: `docs/design/redesign-2026.md` §5 (Newsletter).
+
+### Context
+A demand signal, not a launched newsletter. Capture addresses to our own DB (no provider
+lock-in) with double opt-in and GDPR-compliant storage; if interest accumulates, stand up
+sending later.
+
+### ADLC delivers
+- `Subscriber` model + double opt-in flow (confirm email), unsubscribe token.
+- Signup form in footer + a tasteful home placement; success/confirmation states.
+- GDPR-minded storage (consent timestamp, source); no third-party calls.
+
+### Done when
+- Visitors can subscribe + confirm; addresses stored with consent metadata; unsubscribe works.
+
+### Dependencies
+- **Related:** P1.11 (privacy policy must cover this). **Blocked by:** P1.1 (form styling).
+
+---
+
+## P1.8 — Keyboard command layer (site-as-terminal)
+
+**Labels:** `enhancement`
+
+### Parent
+Epic: Phase 1. Design: `docs/design/redesign-2026.md` §3 (Signature interaction).
+
+### Context
+The personality centerpiece (inspired by commitmono.com): drive the whole site from the
+keyboard. Command palette + single-key shortcuts + a keyboard-guide overlay, unifying
+navigation and theme switching, and extensible so analytics queries (P1.9) can plug in.
+
+### ADLC delivers
+- Command palette overlay (`Cmd/Ctrl-K`, `` ` ``/`:`) — terminal-style input + command registry.
+- Single-key shortcuts: `t` theme, `g h/w/p/l` nav, `/` search focus, `?` guide overlay, `Esc`.
+- Keyboard-guide overlay; extensible command registry for future commands.
+- **A11y:** no focus traps, screen-reader friendly, respects `prefers-reduced-motion`;
+  full functionality without the layer (progressive enhancement).
+
+### Done when
+- Palette + shortcuts + guide work; nav and theme switch via keyboard; a11y checks pass;
+  command registry documented for P1.9 to extend.
+
+### Dependencies
+- **Blocked by:** P1.1 (theme integration). **Feeds:** P1.9 (metrics query commands).
+
+---
+
+## P1.9 — First-party analytics + retire GA/Metricool
+
+**Labels:** `enhancement`
+
+### Parent
+Epic: Phase 1. Design: `docs/design/redesign-2026.md` §6.5.
+
+### Context
+Framed as Bardic Labs' inaugural experiment: keep visitor data on our own infra. Remove
+Google Analytics + Metricool; add lightweight, cookieless first-party event capture to
+Postgres; expose read-only queries through the command layer.
+
+### ADLC delivers
+- Remove GA (`G-TWP4CV64DK`) + Metricool snippets from the layout.
+- First-party event capture (page views, referrer, basic UTM) → Postgres; cookieless where
+  possible; likely an `analytics` subsystem.
+- Command-layer queries (`stats views --last 7d`, `top posts`, `referrers`) via P1.8.
+
+### Done when
+- GA/Metricool gone; views recorded first-party; at least one metric queryable in the terminal.
+
+### Dependencies
+- **Blocked by:** P1.8 (command layer). **Open detail:** public vs owner-only query scope (§8).
+
+---
+
+## P1.10 — SEO / meta / structured-data polish
+
+**Labels:** `enhancement`
+
+### Parent
+Epic: Phase 1. Design: `docs/design/redesign-2026.md` §7 (item 8).
+
+### Context
+Improve discoverability/professionalism: per-page OG images and JSON-LD structured data.
+
+### ADLC delivers
+- Per-page Open Graph / Twitter images (or a templated generator).
+- JSON-LD `Person` (site-wide) and `Article` (posts) structured data.
+- Sanity pass on titles/descriptions/canonicals across pages.
+
+### Done when
+- Pages emit correct OG + JSON-LD; validates in a structured-data testing tool.
+
+### Dependencies
+- **Soft-depends:** P1.4 (article metadata).
+
+---
+
+## P1.11 — Legal: Impressum + privacy policy
+
+**Labels:** `documentation`, `enhancement`
+
+### Parent
+Epic: Phase 1. Design: `docs/design/redesign-2026.md` §8 (Legal).
+
+### Context
+Berlin-based site: German law requires an **Impressum**; GDPR + TTDSG require a privacy
+policy covering first-party analytics (P1.9) and the newsletter (P1.7). Dedicated ticket.
+
+### ADLC delivers
+- `/impressum` page (legally required disclosures).
+- `/privacy` policy page covering first-party analytics, newsletter, cookies/localStorage.
+- Footer links to both.
+
+### Done when
+- Both pages live and linked; content reviewed against current GDPR/TTDSG/Impressum needs.
+
+### Manual ops
+- Owner confirms the legal disclosures are accurate (consider professional review).
+
+### Dependencies
+- **Related:** P1.7, P1.9 (must be reflected in the policy).
+
+---
+
+## P1.12 — Build-in-public: /changelog + site version
+
+**Labels:** `enhancement`, `documentation`
+
+### Parent
+Epic: Phase 1. Design: `docs/design/redesign-2026.md` §7 (item 12).
+
+### Context
+Document the refresh publicly: a `/changelog` page and a site version in the footer. The
+companion "Rebuilding this site" **Notes series** is ongoing editorial (written via P1.4),
+not part of this code issue.
+
+### ADLC delivers
+- `/changelog` page (sourced from markdown or a simple model).
+- Site version shown in the footer.
+
+### Done when
+- `/changelog` renders and footer shows the current version.
+
+### Dependencies
+- **Soft-depends:** P1.4 (if changelog reuses the markdown pipeline).


### PR DESCRIPTION
## Summary

Adds the consolidated design reference for the site redesign plus the Phase-1 issue drafts. **Docs only — no app code changes.**

- `docs/design/redesign-2026.md` — the design doc: positioning (fractional architect/CTO, proof-over-pitch), refined-terminal visual direction (Commit Mono, amber accent, 18px/Major-Third scale, terminal theme picker), the keyboard-driven **site-as-terminal** command layer, Notes vs Deep Dives content model, **Bardic Labs** AI Lab (subdomain-first, Doorkeeper OIDC, Nat 1–Nat 20 rating), Medium POSSE syndication, first-party analytics (retiring GA/Metricool), aspirational newsletter, legal (Impressum/privacy), a phased roadmap, and a decision log.
- `docs/design/redesign-phase1-issues.md` — an epic + 12 right-sized child issue drafts in the repo issue template, with a dependency graph and suggested sequencing.

## Phase 1 scope (in the drafts)

Design system → home/projects/writing/about redesigns → Medium syndication → newsletter → keyboard command layer → first-party analytics → SEO/meta → legal → build-in-public changelog. Phase 2 (Bardic Labs identity/OIDC) is documented but out of scope for these tickets.

## Follow-ups

- Phase-1 drafts to be screened + added to the board by the product agent (triage).
- Open build-time details are tracked in the design doc §8 (theme list, body sans, metrics query scope, social links, `bardiclabs.com` optional reservation).

## Test plan

- [x] Docs render correctly (Markdown + Mermaid).
- [x] No application/code changes; no behavioral impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)