### PR TITLE
[#1184] Add about page and shared Work with me CTA

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -3,6 +3,7 @@
 # The WelcomeController is used to host the landing pages and supplimentary content for the application.
 class WelcomeController < ApplicationController
   def index; end
+  def about; end
   def projects; end
   def resume; end
 end

--- a/app/views/components/_work_with_me_cta.html.erb
+++ b/app/views/components/_work_with_me_cta.html.erb
@@ -1,0 +1,23 @@
+<%#
+  Shared "Work with me" CTA block.
+
+  Call shape:
+    render "components/work_with_me_cta"
+    render "components/work_with_me_cta", supporting_copy: "Custom supporting sentence."
+
+  Locals:
+    supporting_copy: optional -- overrides the default supporting sentence
+
+  href is sourced from resume_data[:basics][:email] (resume/resume.yml) so a future
+  form or booking URL is a one-line swap here.
+%>
+<%
+  default_copy = "Have a hard technical decision in front of you, or a team that could use an outside perspective? Let's talk."
+  copy = local_assigns[:supporting_copy] || default_copy
+%>
+<%= render layout: "components/section", locals: { eyebrow: "Get in touch" } do %>
+  <div class='text-center'>
+    <p class='text-lg text-base-content/70 mb-6'><%= copy %></p>
+    <%= render "components/cta_button", label: "Work with me", href: "mailto:#{resume_data[:basics][:email]}", style: :primary %>
+  </div>
+<% end %>

--- a/app/views/layouts/components/_footer.html.erb
+++ b/app/views/layouts/components/_footer.html.erb
@@ -22,6 +22,7 @@
             <ul class='flex flex-col list-none justify-center items-center md:items-start gap-2 mb-10 text-sm'>
               <%= link_to 'Writing', posts_url, class: 'link link-hover' %>
               <%= link_to 'Projects', projects_url, class: 'link link-hover' %>
+              <%= link_to 'About', about_path, class: 'link link-hover' %>
               <%= link_to 'Resume', resume_url, class: 'link link-hover' %>
             </ul>
           </div>
@@ -53,5 +54,6 @@
           </div>
         </div>
       </div>
+      <%= render "components/work_with_me_cta" %>
     </div>
   </footer>

--- a/app/views/layouts/components/_header.html.erb
+++ b/app/views/layouts/components/_header.html.erb
@@ -12,6 +12,7 @@
       <li class='ml-4'><%= link_to 'Home', root_url, class: current_page?(root_path) ? 'text-primary cursor-default' : 'link link-hover', data: { nav_target: 'home' } %></li>
       <li class='ml-4'><%= link_to 'Writing', posts_url, class: current_page?(posts_path) ? 'text-primary cursor-default' : 'link link-hover', data: { nav_target: 'writing' } %></li>
       <li class='ml-4'><%= link_to 'Projects', projects_url, class: current_page?(projects_url) ? 'text-primary cursor-default' : 'link link-hover', data: { nav_target: 'projects' } %></li>
+      <li class='ml-4'><%= link_to 'About', about_path, class: current_page?(about_path) ? 'text-primary cursor-default' : 'link link-hover', data: { nav_target: 'about' } %></li>
       <li class='ml-4'><%= link_to 'Resume', resume_path, class: current_page?(resume_url) ? 'text-primary cursor-default' : 'link link-hover', data: { nav_target: 'resume' } %></li>
       <%# Terminal-styled theme switcher (R6). data-theme-picker-target="select" is read
           by app/javascript/controllers/theme_picker_controller.js; the render-blocking

--- a/app/views/welcome/about.html.erb
+++ b/app/views/welcome/about.html.erb
@@ -1,0 +1,53 @@
+<%
+  set_meta_tags(
+    title: "About — James Ebentier",
+    description: "Fractional software architect based in Berlin. I embed with engineering teams to unblock hard technical decisions and mentor the people who'll own the system long after I'm gone.",
+  )
+%>
+
+<%# Hero: the page's one <h1> (positioning line from redesign-2026.md §2). Deliberately
+    outside components/section -- same pattern as the home hero and project show pages. %>
+<div class='mb-16'>
+  <p class='font-mono text-sm text-primary mb-2'>$ cat about.md</p>
+  <h1 class='font-mono text-3xl mb-4'>I help engineers get their systems right — a fraction of the time, all of the leverage.</h1>
+  <p class='text-lg text-base-content/70'>James Ebentier — software architect based in Berlin. I embed with engineering teams to unblock hard technical decisions and mentor the people who'll own the system long after I'm gone.</p>
+</div>
+
+<%= render layout: "components/section", locals: { title: "What I do" } do %>
+  <div class='prose max-w-none'>
+    <p>
+      I'm a fractional architect: I join a team for a defined stretch — weeks or months, not years —
+      to help you make the technical calls that are hard to make from the inside. Platform direction,
+      delivery bottlenecks, architectural debt, the migration you've been putting off. I bring an outside
+      perspective, hands-on depth, and a bias toward leaving things clearer than I found them.
+    </p>
+    <p>
+      This isn't a pitch deck or a services menu. The work speaks through
+      <%= link_to "what I've shipped", projects_url, class: "link link-primary" %>
+      and
+      <%= link_to "what I've written", posts_url, class: "link link-primary" %>.
+      If those resonate, we might be a good fit.
+    </p>
+  </div>
+<% end %>
+
+<%= render layout: "components/section", locals: { title: "How I work" } do %>
+  <div class='prose max-w-none'>
+    <p>
+      Mentorship is the through-line. The best fractional engagements aren't about one person
+      swooping in to save the day — they're about making the team around you stronger: senior
+      engineers who need a sounding board, tech leads stepping into architecture for the first
+      time, groups that want a shared vocabulary for how systems should evolve.
+    </p>
+    <p>
+      I care about developer experience, feedback loops, and the unglamorous infrastructure that
+      lets product teams move fast without breaking things. If you've read my
+      <%= link_to "resume", resume_path, class: "link link-primary" %>, you'll see that thread
+      running through years of platform and enablement work — it's the same instinct, applied on
+      a smaller, sharper scope.
+    </p>
+  </div>
+<% end %>
+
+<%= render "components/work_with_me_cta",
+           supporting_copy: "Curious whether an outside architect could help your team? Drop me a line — no pitch, just a conversation." %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -90,14 +90,4 @@
   <% end %>
 <% end %>
 
-<%# "Work with me" CTA -- last on the page (R5), understated per the design doc's "no
-    banners" direction: a modest eyebrow, one supporting sentence, one primary
-    cta_button. mailto: target is sourced from resume_data (resume/resume.yml) -- the
-    one real, published contact address already in the codebase -- not a second
-    hardcoded literal. %>
-<%= render layout: "components/section", locals: { eyebrow: "Get in touch" } do %>
-  <div class='text-center'>
-    <p class='text-lg text-base-content/70 mb-6'>Have a hard technical decision in front of you, or a team that could use an outside perspective? Let's talk.</p>
-    <%= render "components/cta_button", label: "Work with me", href: "mailto:#{resume_data[:basics][:email]}", style: :primary %>
-  </div>
-<% end %>
+<%= render "components/work_with_me_cta" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get "writing/:slug"  => "writing#show",     as: :post
   get "projects"       => "projects#index",   as: :projects
   get "projects/:slug" => "projects#show",    as: :project
+  get "about"          => "welcome#about",    as: :about
   get "resume"         => "welcome#resume",   as: :resume
 
   # SEARCH mode's content index (#1187 R9) -- a JSON array of Post/Project items,

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -40,6 +40,8 @@ SitemapGenerator::Sitemap.create do
     end
   end
 
+  add about_path, priority: 0.7, changefreq: "weekly"
+
   # Add any contoller index methods that are not already included or have noindex? set to true
   ApplicationController.descendants.each do |controller|
     next if controller.noindex? || controller.instance_methods.exclude?(:index) || !respond_to?(:"#{controller.name.underscore}_path")

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -108,6 +108,7 @@ Every non-test file under `app/` and `lib/` appears here exactly once. Reviewers
 - `app/views/components/_cta_button.html.erb` — Shared CTA button partial (primary/ghost)
 - `app/views/components/_pill.html.erb` — Shared tag/status pill partial (status→badge-role map)
 - `app/views/components/_section.html.erb` — Shared section wrapper partial (eyebrow/title + scroll motion)
+- `app/views/components/_work_with_me_cta.html.erb` — Shared "Work with me" mailto CTA block (home/about/footer)
 - `app/views/layouts/application.html.erb` — Main HTML layout (meta-tags, analytics, FOUC-prevention theme script)
 - `app/views/layouts/components/_header.html.erb` — Site header
 - `app/views/layouts/components/_footer.html.erb` — Site footer
@@ -116,6 +117,7 @@ Every non-test file under `app/` and `lib/` appears here exactly once. Reviewers
 - `app/views/projects/index.html.erb` — Projects listing
 - `app/views/projects/index.rss.builder` — Projects RSS
 - `app/views/projects/show.html.erb` — Project detail
+- `app/views/welcome/about.html.erb` — About page (fractional-architect narrative)
 - `app/views/welcome/index.html.erb` — Landing page
 - `app/views/welcome/resume.html.erb` — Resume page shell
 - `app/views/welcome/resume/_education.html.erb` — Resume education partial

--- a/docs/design/2026-07-20-about-page-design.md
+++ b/docs/design/2026-07-20-about-page-design.md
@@ -1,0 +1,102 @@
+# About page + Work-with-me CTA — Design (#1184)
+
+> **Status:** Awaiting operator approval · **Issue:** [#1184](https://github.com/bitidev/jamesebentier.com/issues/1184) · **Parent:** Phase 1 epic (#1179), `docs/design/redesign-2026.md` §2 & §4
+
+## Problem
+
+The redesign positions James as a fractional architect / CTO — proof over pitch — but there is
+no `/about` page to carry that narrative. P1.1 (#1181) shipped the home-page "Work with me"
+CTA as a real `mailto:` link; P1.5 completes the contact surface by adding the about story
+and placing the same CTA on `/about` and in the footer, structured so the target can later
+swap to a form or booking flow without a layout rewrite.
+
+## Chosen approach
+
+### Route & controller
+
+- Add `GET /about` → `WelcomeController#about` (same controller family as home/resume).
+- View: `app/views/welcome/about.html.erb`.
+
+### Shared CTA partial
+
+Extract the home page's "Work with me" block into a reusable partial:
+
+```
+app/views/components/_work_with_me_cta.html.erb
+```
+
+- Renders the existing pattern: `components/section` wrapper, eyebrow `"Get in touch"`,
+  one supporting sentence, `components/cta_button` (`label: "Work with me"`, `style: :primary`).
+- `href` sourced from `resume_data[:basics][:email]` (single source of truth in
+  `resume/resume.yml`) — same as home today.
+- Optional local `supporting_copy:` to override the default sentence on `/about` if the page
+  needs context-specific wording; home and footer use the default.
+
+Refactor `welcome/index.html.erb` to render this partial instead of inlining the CTA block.
+
+### About page content & layout
+
+Static ERB narrative composed from P1.1 primitives — no new components, no DB model.
+
+Structure (all sections via `components/section` except the page `<h1>`, mirroring home/projects
+patterns):
+
+1. **Hero** — page `<h1>` with the positioning line from §2 (`"I help engineers get their
+   systems right — a fraction of the time, all of the leverage."`), plus a short subhead
+   (Berlin-based software architect; embeds with teams; mentors engineers).
+2. **What I do** — fractional-architect framing: unblock hard technical decisions, improve
+   systems and delivery, leave teams stronger than you found them. Tone: demonstration, not
+   solicitation.
+3. **How I work** — mentorship + community as the through-line (aligns with Bardic Labs /
+   "bard as support class" positioning without naming the lab yet — `/lab` is Phase 2).
+4. **Proof** — brief pointer to Writing and Projects as evidence; inline links, no case-study
+   carousel.
+5. **CTA** — render `components/work_with_me_cta` at page bottom (about-specific supporting
+   copy if it reads better in context).
+
+Typography: `prose` / existing token classes for body copy; headings in Commit Mono (`font-mono`).
+
+Meta: `set_meta_tags` with a concise title/description suitable for sharing (full OG polish is
+P1.10's job — no new meta infrastructure here).
+
+### Navigation & discoverability
+
+- **Header:** add an "About" link (between Projects and Resume), with `data-nav-target="about"`
+  for future keyboard-nav parity. No `:about` COMMAND/`g`-jump wiring in this issue — that's
+  optional follow-up to #1187.
+- **Footer Links column:** add `About` alongside Writing / Projects / Resume.
+- **Footer CTA:** render `components/work_with_me_cta` below the link columns (full-width,
+  centered — same understated treatment as home, not a banner).
+- **Sitemap:** add `about_path` explicitly in `config/sitemap.rb` (the auto-discovery hook
+  only picks up `#index` actions).
+
+### Future-proofing the CTA target
+
+The partial is the single swap point. When a contact form or booking URL arrives, change
+`href` (and optionally `label`) in one partial — or introduce a `ContactHelper#work_with_me_href`
+if the target becomes environment-driven. No route or layout changes required.
+
+## Acceptance criteria
+
+- [ ] `GET /about` returns 200 with the fractional-architect + mentorship narrative.
+- [ ] Page uses existing `components/section`, `components/cta_button` — no new design-system
+  components.
+- [ ] Shared `components/work_with_me_cta` partial exists; home, about, and footer all render
+  it.
+- [ ] CTA `href` is `mailto:` sourced from `resume/resume.yml` via `resume_data` — opens email
+  client when clicked.
+- [ ] Header and footer include an About link to `/about`.
+- [ ] `/about` appears in the generated sitemap.
+- [ ] Request specs cover `/about` (200, meta, CTA mailto), footer CTA presence, and that
+  home still renders the shared partial correctly.
+
+## Open questions
+
+1. **Copy review** — the narrative draft above follows §2 positioning; do you want to supply
+   exact wording, or is implementer-drafted copy (reviewable in the PR) acceptable?
+2. **Header order** — proposed: Home · Writing · Projects · **About** · Resume. Prefer a
+   different slot?
+3. **Keyboard nav** — defer `:about` COMMAND/`g a` binding to a #1187 follow-up, or include a
+   minimal registry + `data-nav-target` wiring in this PR?
+4. **Footer CTA placement** — proposed: below the three footer columns. Prefer it inside the
+   Links column instead (more compact, less prominent)?

--- a/spec/requests/about_spec.rb
+++ b/spec/requests/about_spec.rb
@@ -14,10 +14,15 @@ RSpec.describe "About page (1184)" do
       expect(response).to have_http_status(:ok)
     end
 
-    it "sets page meta tags for sharing" do
+    it "sets the about page title meta tag" do
       get about_path
 
       expect(response.body).to include("About — James Ebentier")
+    end
+
+    it "sets the about page description meta tag" do
+      get about_path
+
       expect(response.body).to include("Fractional software architect based in Berlin")
     end
 
@@ -29,21 +34,41 @@ RSpec.describe "About page (1184)" do
       )
     end
 
-    it "links the Work with me CTA to a mailto: address sourced from resume.yml" do
+    it "renders at least one Work with me CTA on about" do
       get about_path
 
       ctas = response.parsed_body.css("a.btn-primary").select { |link| link.text == "Work with me" }
+
       expect(ctas).not_to be_empty
-      expect(ctas.map { |cta| cta["href"] }).to all(eq("mailto:#{expected_email}"))
     end
 
-    it "includes narrative sections with proof links to writing and projects" do
+    it "links each about-page Work with me CTA to resume.yml mailto" do
+      get about_path
+
+      ctas = response.parsed_body.css("a.btn-primary").select { |link| link.text == "Work with me" }
+
+      expect(ctas.pluck("href")).to all(eq("mailto:#{expected_email}"))
+    end
+
+    it "includes the What I do and How I work section headings" do
       get about_path
 
       body = response.parsed_body
-      expect(body.text).to include("What I do", "How I work", "what I've shipped", "what I've written")
-      expect(body.css("a[href*='projects']").map(&:text)).to include("what I've shipped")
-      expect(body.css("a[href*='writing']").map(&:text)).to include("what I've written")
+      expect(body.text).to include("What I do", "How I work")
+    end
+
+    it "includes a proof link to projects" do
+      get about_path
+
+      project_link_texts = response.parsed_body.css("a[href*='projects']").map(&:text)
+      expect(project_link_texts).to include("what I've shipped")
+    end
+
+    it "includes a proof link to writing" do
+      get about_path
+
+      writing_link_texts = response.parsed_body.css("a[href*='writing']").map(&:text)
+      expect(writing_link_texts).to include("what I've written")
     end
   end
 
@@ -66,11 +91,17 @@ RSpec.describe "About page (1184)" do
   end
 
   describe "navigation" do
-    it "includes an About link in the header with data-nav-target for future keyboard nav" do
+    it "includes an About link in the header for future keyboard nav wiring" do
       get about_path
 
       about_link = response.parsed_body.at_css("header a[data-nav-target='about']")
       expect(about_link.text).to eq("About")
+    end
+
+    it "links the header About nav item to /about" do
+      get about_path
+
+      about_link = response.parsed_body.at_css("header a[data-nav-target='about']")
       expect(about_link["href"]).to eq(about_path)
     end
 

--- a/spec/requests/about_spec.rb
+++ b/spec/requests/about_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "About page (1184)" do
+  let(:expected_email) do
+    YAML.safe_load_file(Rails.root.join("resume/resume.yml"), symbolize_names: true).dig(:basics, :email)
+  end
+
+  describe "GET /about" do
+    it "returns a successful response" do
+      get about_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "sets page meta tags for sharing" do
+      get about_path
+
+      expect(response.body).to include("About — James Ebentier")
+      expect(response.body).to include("Fractional software architect based in Berlin")
+    end
+
+    it "carries the positioning line as the page <h1>" do
+      get about_path
+
+      expect(response.parsed_body.at_css("h1").text).to include(
+        "I help engineers get their systems right — a fraction of the time, all of the leverage."
+      )
+    end
+
+    it "links the Work with me CTA to a mailto: address sourced from resume.yml" do
+      get about_path
+
+      ctas = response.parsed_body.css("a.btn-primary").select { |link| link.text == "Work with me" }
+      expect(ctas).not_to be_empty
+      expect(ctas.map { |cta| cta["href"] }).to all(eq("mailto:#{expected_email}"))
+    end
+
+    it "includes narrative sections with proof links to writing and projects" do
+      get about_path
+
+      body = response.parsed_body
+      expect(body.text).to include("What I do", "How I work", "what I've shipped", "what I've written")
+      expect(body.css("a[href*='projects']").map(&:text)).to include("what I've shipped")
+      expect(body.css("a[href*='writing']").map(&:text)).to include("what I've written")
+    end
+  end
+
+  describe "shared Work with me CTA placement" do
+    it "renders the CTA on the home page" do
+      get root_path
+
+      cta = response.parsed_body.css("a.btn-primary").find { |link| link.text == "Work with me" }
+      expect(cta["href"]).to eq("mailto:#{expected_email}")
+    end
+
+    it "renders the CTA in the site footer" do
+      get root_path
+
+      footer = response.parsed_body.at_css("footer")
+      footer_cta = footer.css("a.btn-primary").find { |link| link.text == "Work with me" }
+
+      expect(footer_cta["href"]).to eq("mailto:#{expected_email}")
+    end
+  end
+
+  describe "navigation" do
+    it "includes an About link in the header with data-nav-target for future keyboard nav" do
+      get about_path
+
+      about_link = response.parsed_body.at_css("header a[data-nav-target='about']")
+      expect(about_link.text).to eq("About")
+      expect(about_link["href"]).to eq(about_path)
+    end
+
+    it "includes an About link in the footer Links column" do
+      get about_path
+
+      footer_links = response.parsed_body.at_css("footer").css("a").map(&:text)
+      expect(footer_links).to include("About")
+    end
+  end
+end

--- a/spec/requests/header_nav_spec.rb
+++ b/spec/requests/header_nav_spec.rb
@@ -18,19 +18,19 @@ RSpec.describe "Header nav markup (1187 regression guard)" do
       expect(header.css("ul").size).to eq(1)
     end
 
-    it "wraps the Home/Writing/Projects/Resume nav <li> items inside that single <ul>" do
+    it "wraps the Home/Writing/Projects/About/Resume nav <li> items inside that single <ul>" do
       get root_path
       nav_ul = response.parsed_body.at_css("header ul")
 
-      expect(nav_ul.css("li").size).to be >= 4
+      expect(nav_ul.css("li").size).to be >= 5
     end
 
-    it "wraps the Home/Writing/Projects/Resume nav links inside that single <ul>" do
+    it "wraps the Home/Writing/Projects/About/Resume nav links inside that single <ul>" do
       get root_path
       nav_ul = response.parsed_body.at_css("header ul")
       nav_texts = nav_ul.css("li a").map(&:text)
 
-      expect(nav_texts).to include("Home", "Writing", "Projects", "Resume")
+      expect(nav_texts).to include("Home", "Writing", "Projects", "About", "Resume")
     end
 
     it "carries the load-bearing right-align/row-flex layout classes on that <ul> (bd4bad7)" do


### PR DESCRIPTION
## Summary

- Adds `/about` with the fractional-architect + mentorship narrative (positioning line, What I do / How I work sections, proof links to Writing and Projects).
- Extracts `components/work_with_me_cta` partial (mailto from `resume/resume.yml`) and uses it on home, about, and footer.
- Wires About into header (between Projects and Resume) and footer Links; adds `/about` to the sitemap.

Closes #1184

## Test plan

- [x] `GET /about` returns 200 with positioning h1, meta tags, and narrative sections
- [x] Work with me CTA on home, about, and footer links to `mailto:` from resume.yml
- [x] Header/footer include About link; header has `data-nav-target="about"` for future #1187 wiring
- [x] Request specs: `spec/requests/about_spec.rb`, updated `header_nav_spec.rb`, `welcome_spec.rb` still pass


Made with [Cursor](https://cursor.com)