### PR TITLE
[#1201] Fix Post factory default file_path basename

### DIFF
--- a/spec/factories/post.rb
+++ b/spec/factories/post.rb
@@ -13,7 +13,8 @@ FactoryBot.define do
     # own full-URL convention, which the same components/_card partial already renders safely.
     image { "https://example.com/logo192.png" }
     published_at { Time.current }
-    file_path { 'blog/the-blog-is-back.md' }
+    # Basename only -- Post#content reads Rails.public_path.join('blog', file_path).
+    file_path { '2024-06-17-Why-Is-Automated-Testing-Important.md' }
     # kind mirrors spec/factories/project.rb's own `status { "Beta" }` convention of stating
     # the schema default explicitly rather than relying on it silently. excerpt is
     # presence-validated with no schema default that satisfies it (P1.4/#1183 D4), so every

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -133,6 +133,20 @@ RSpec.describe Post do
     end
   end
 
+  describe 'factory default file_path (1201 regression)' do
+    it 'points at an existing public/blog markdown file' do
+      post = create(:post)
+
+      expect(Rails.public_path.join('blog', post.file_path)).to exist
+    end
+
+    it 'loads content without Errno::ENOENT' do
+      post = create(:post)
+
+      expect { post.content }.not_to raise_error
+    end
+  end
+
   # Computed, not stored (D5) -- Post#content is stubbed here to isolate the word-count/
   # ceiling/minimum-1 math from the real, uncached disk read (the filesystem is an external
   # boundary per the test-audit mock-boundary rules), so these boundary cases stay
@@ -160,7 +174,7 @@ RSpec.describe Post do
     end
 
     it 'computes from the real on-disk markdown body via the real, unstubbed #content (wiring check)' do
-      post = create(:post, file_path: '2024-06-17-Why-Is-Automated-Testing-Important.md')
+      post = create(:post)
 
       # This fixture's body (front matter stripped) is 540 words -- ceil(540 / 200.0) = 3.
       # A hardcoded expectation (not a recomputed copy of the implementation's own formula)

--- a/spec/requests/writing_spec.rb
+++ b/spec/requests/writing_spec.rb
@@ -5,14 +5,10 @@ require 'rails_helper'
 # GET /writing, /writing/:slug (R3, R5, R6) -- the Notes/Deep Dives content model's
 # public-facing pages, migrated onto the shared components/_section/_card/_pill/_cta_button
 # partials (R6), mirroring spec/requests/projects_spec.rb's own real-controller/view-stack
-# style (see adlc/methods/code-quality/call-site-wiring-verification.md). Every fixture below
-# sets a real, on-disk file_path -- Post#reading_time (rendered on both the index card and the
-# show page's metadata row) reads Post#content, an uncached disk read of a file the factory's
-# own default file_path does NOT point at (see spec/factories/post.rb's own comment) -- the
-# same convention spec/system/keyboard_nav_*_spec.rb already established.
+# style (see adlc/methods/code-quality/call-site-wiring-verification.md). Post#reading_time
+# (index card + show metadata) reads Post#content from disk; the factory default file_path
+# points at a real public/blog fixture (#1201).
 RSpec.describe 'Writing' do
-  let(:on_disk_file_path) { '2024-06-17-Why-Is-Automated-Testing-Important.md' }
-
   describe 'GET /writing' do
     context 'when there are no posts' do
       it 'returns a successful response' do
@@ -36,17 +32,17 @@ RSpec.describe 'Writing' do
 
     context 'when there are posts of mixed kind and publish date' do
       let!(:oldest_note) do
-        create(:post, slug: 'oldest-note', kind: 'note', published_at: 3.days.ago, file_path: on_disk_file_path)
+        create(:post, slug: 'oldest-note', kind: 'note', published_at: 3.days.ago)
       end
       let!(:middle_note) do
-        create(:post, slug: 'middle-note', kind: 'note', published_at: 2.days.ago, file_path: on_disk_file_path)
+        create(:post, slug: 'middle-note', kind: 'note', published_at: 2.days.ago)
       end
       let!(:newest_deep_dive) do
-        create(:post, slug: 'newest-deep-dive', kind: 'deep_dive', published_at: 1.day.ago, file_path: on_disk_file_path)
+        create(:post, slug: 'newest-deep-dive', kind: 'deep_dive', published_at: 1.day.ago)
       end
 
       before do
-        create(:post, slug: 'future-post', kind: 'deep_dive', published_at: 1.day.from_now, file_path: on_disk_file_path)
+        create(:post, slug: 'future-post', kind: 'deep_dive', published_at: 1.day.from_now)
       end
 
       it 'renders one card per published post, excluding the unpublished future post' do
@@ -92,8 +88,7 @@ RSpec.describe 'Writing' do
           kind: 'note',
           excerpt: 'A short teaser for the note.',
           tags: %w[ruby rails],
-          published_at: Time.zone.parse('2026-01-15'),
-          file_path: on_disk_file_path
+          published_at: Time.zone.parse('2026-01-15')
         )
       end
 
@@ -144,7 +139,7 @@ RSpec.describe 'Writing' do
     end
 
     context 'with a Deep Dive post card' do
-      before { create(:post, slug: 'a-deep-dive', kind: 'deep_dive', file_path: on_disk_file_path) }
+      before { create(:post, slug: 'a-deep-dive', kind: 'deep_dive') }
 
       it 'renders the Deep Dive kind badge with the badge-accent role (D7)' do
         get posts_path
@@ -176,8 +171,7 @@ RSpec.describe 'Writing' do
         kind: 'note',
         excerpt: 'A short teaser for the article.',
         tags: %w[ruby],
-        published_at: Time.zone.parse('2026-01-15'),
-        file_path: on_disk_file_path
+        published_at: Time.zone.parse('2026-01-15')
       )
     end
 

--- a/spec/system/keyboard_nav_normal_navigation_spec.rb
+++ b/spec/system/keyboard_nav_normal_navigation_spec.rb
@@ -19,8 +19,8 @@ require "rails_helper"
 # no explicit focus target lands on document.activeElement (document.body by default
 # on a fresh page load), exactly what the feature's document-level listener expects.
 RSpec.describe "Keyboard navigation -- NORMAL-mode navigation", :js do
-  # A long, real markdown post (not the factory's default nonexistent file_path) so the
-  # rendered page is tall enough to actually exercise gg/G scrolling.
+  # Long markdown fixture for scroll/hint-jump coverage (distinct from the factory default).
+  # The rendered page must be tall enough to exercise gg/G scrolling.
   let!(:long_post) do
     create(
       :post,

--- a/spec/system/keyboard_nav_search_spec.rb
+++ b/spec/system/keyboard_nav_search_spec.rb
@@ -22,9 +22,8 @@ require "rails_helper"
 # typing/n/N/Enter use ordinary Capybara `fill_in`/`send_keys` -- there is no ambiguous
 # full-height-body-click concern for a small, on-screen, already-focused <input>.
 RSpec.describe "Keyboard navigation -- SEARCH mode (/)", :js do
-  # file_path points at a real markdown file under public/blog (not the factory's default,
-  # nonexistent path) -- the Enter-navigates test below actually visits this post's show
-  # page, which calls Post#content and reads that file from disk.
+  # Long markdown fixture for search-index coverage (distinct from the factory default).
+  # The Enter-navigates test below visits this post's show page, which reads the file from disk.
   let!(:aws_post) do
     create(
       :post,


### PR DESCRIPTION
## Summary

- Fixes the Post factory default `file_path` from `blog/the-blog-is-back.md` (doubled to `public/blog/blog/...` by `Post#content`) to a real on-disk basename: `2024-06-17-Why-Is-Automated-Testing-Important.md`.
- Adds regression specs ensuring `create(:post)` resolves a real markdown file and loads content without `Errno::ENOENT`.
- Removes compensating `file_path` overrides from `writing_spec.rb`; keyboard-nav specs keep their long-fixture overrides (intentional, not compensating).

Closes #1201

## Test plan

- [x] `bundle exec rubocop` on touched spec files
- [x] `bundle exec rspec spec/models/post_spec.rb spec/requests/writing_spec.rb` — 71 examples, 0 failures


Made with [Cursor](https://cursor.com)