### PR TITLE
[#1200] Fix writing RSS channel link and description typo

### DIFF
--- a/app/views/writing/index.rss.builder
+++ b/app/views/writing/index.rss.builder
@@ -4,12 +4,12 @@ xml.instruct! :xml, version: "1.0"
 xml.rss version: "2.0" do
   xml.channel do
     xml.title "Writing | James Ebentier | RSS"
-    xml.description "The blog of James Ebentier documenting his current leadning and what he is building through Biti LLC."
-    xml.link projects_url
+    xml.description "The blog of James Ebentier documenting his current learning and what he is building through Biti LLC."
+    xml.link posts_url
     xml.image do
       xml.url "https://jamesebentier.com/logo.png"
       xml.title "James Ebentier Writing"
-      xml.link projects_url
+      xml.link posts_url
     end
 
     Post.published.find_each do |blog|

--- a/spec/requests/writing_spec.rb
+++ b/spec/requests/writing_spec.rb
@@ -225,6 +225,46 @@ RSpec.describe 'Writing' do
     end
   end
 
+  describe 'GET /writing.rss' do
+    it 'returns a successful response' do
+      get posts_path(format: :rss)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns application/rss+xml' do
+      get posts_path(format: :rss)
+
+      expect(response.media_type).to eq('application/rss+xml')
+    end
+
+    it 'points the channel link at the writing index' do
+      get posts_path(format: :rss)
+
+      channel_link = Nokogiri::XML(response.body).at('channel > link').text
+      expect(channel_link).to eq(posts_url)
+    end
+
+    it 'points the channel image link at the writing index' do
+      get posts_path(format: :rss)
+
+      image_link = Nokogiri::XML(response.body).at('channel image link').text
+      expect(image_link).to eq(posts_url)
+    end
+
+    it 'does not include the pre-existing leadning typo in the channel description' do
+      get posts_path(format: :rss)
+
+      expect(response.body).not_to include('leadning')
+    end
+
+    it 'uses learning in the channel description' do
+      get posts_path(format: :rss)
+
+      expect(response.body).to include('learning')
+    end
+  end
+
   describe 'GET /blog (retired route -- D2/R3, no redirect)' do
     it 'no longer resolves -- returns 404, not a redirect' do
       get '/blog'


### PR DESCRIPTION
## Summary

- Points the writing RSS channel `<link>` and image `<link>` at `posts_url` (the `/writing` index) instead of `projects_url`.
- Fixes the channel description typo (`leadning` → `learning`).
- Adds request specs asserting RSS content type, channel links, and description copy.

Closes #1200

## Test plan

- [x] `bundle exec rubocop` on touched files
- [x] `bundle exec rspec spec/requests/writing_spec.rb` — 35 examples, 0 failures


Made with [Cursor](https://cursor.com)