### PR TITLE
[#1196] Fix :help dialog Escape refocus after COMMAND mode

### DIFF
--- a/app/javascript/controllers/keyboard_nav_controller.js
+++ b/app/javascript/controllers/keyboard_nav_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 import { resolveNavTarget } from "../keyboard_nav/resolve_nav_target"
 import { nextTheme } from "../keyboard_nav/theme_cycle"
-import { COMMAND_REGISTRY, findCommand, formatCommandInvocation, parseCommand, rankCommands } from "../keyboard_nav/commands"
+import { COMMAND_REGISTRY, findCommand, formatCommandInvocation, parseCommand, rankCommands, willCommandApply } from "../keyboard_nav/commands"
 import { fetchSearchIndex, rankSearchResults } from "../keyboard_nav/search_index"
 import { assignHintLabels } from "../keyboard_nav/hints"
 
@@ -556,16 +556,18 @@ export default class extends Controller {
     if (!name) return
 
     const command = findCommand(name, COMMAND_REGISTRY)
-    const result = command ? command.run(args, this.commandContext()) : false
-
-    if (result === false) {
+    if (!command || !willCommandApply(command, args)) {
       this.setCommandFeedback(`${name}: command not found`)
       return
     }
 
     this.commandInputTarget.value = ""
     this.clearCommandFeedback()
+    // Exit COMMAND mode (blur + restore priorFocus) before run() -- especially
+    // openGuideDialog/showModal() -- so the native <dialog>'s own focus-restore on
+    // Esc-close returns to the pre-COMMAND target, not the now-hidden command input.
     this.exitToNormal()
+    command.run(args, this.commandContext())
   }
 
   // Bound methods handed to a command's run(args, context) -- each delegates to this

--- a/app/javascript/controllers/keyboard_nav_controller.js
+++ b/app/javascript/controllers/keyboard_nav_controller.js
@@ -545,12 +545,13 @@ export default class extends Controller {
   }
 
   // Enter (spec R6): parseCommand the current input, look up by exact name/alias/
-  // unambiguous prefix (findCommand), run it against a context bound to this
-  // controller's own single-source-of-truth methods. An empty name (bare Enter with
-  // nothing typed) is a silent no-op -- there's nothing to be "not found." A `run` that
-  // returns `false` (e.g. `:theme bogus-name`, an unrecognized theme) is treated
-  // identically to an unrecognized command name -- one visible "not found" state, not
-  // two. On success: clear the input and return to NORMAL, restoring prior focus.
+  // unambiguous prefix (findCommand), then willCommandApply for side-effect-free
+  // preflight (today: `:theme` arg validity). An empty name (bare Enter with nothing
+  // typed) is a silent no-op -- there's nothing to be "not found." Missing command or
+  // failed preflight keep the bar open with one shared "not found" feedback state.
+  // On success: clear the input, exitToNormal (blur + restore priorFocus), then run()
+  // -- exit before run so showModal() (e.g. `:help`) does not capture the command
+  // input as the dialog's focus-restore target.
   commitCommand() {
     const { name, args } = parseCommand(this.commandInputTarget.value)
     if (!name) return

--- a/app/javascript/keyboard_nav/commands.js
+++ b/app/javascript/keyboard_nav/commands.js
@@ -113,6 +113,17 @@ export function formatCommandInvocation(command) {
 // exactly one entry's name starts with it (an "unambiguous prefix" -- two+ matches is
 // treated the same as no match, since Enter must invoke one specific command, never
 // guess between several).
+// willCommandApply(command, args) -> whether run() would succeed without side effects.
+// Used by commitCommand() to reject bad input before exitToNormal(), since only `:theme`
+// can return false today -- every other v1 command always applies once found.
+export function willCommandApply(command, args) {
+  if (command.name === "theme") {
+    return THEME_CYCLE_ORDER.includes(args.trim())
+  }
+
+  return true
+}
+
 export function findCommand(name, registry) {
   const query = (name || "").trim().toLowerCase()
   if (!query) return null

--- a/app/javascript/keyboard_nav/commands.test.js
+++ b/app/javascript/keyboard_nav/commands.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
-import { COMMAND_REGISTRY, findCommand, formatCommandInvocation, parseCommand, rankCommands } from "./commands"
+import { COMMAND_REGISTRY, findCommand, formatCommandInvocation, parseCommand, rankCommands, willCommandApply } from "./commands"
 
 describe("parseCommand", () => {
   it("parses a bare name with no args", () => {
@@ -163,5 +163,15 @@ describe("COMMAND_REGISTRY (v1 command set, spec R6)", () => {
 
     expect(context.setTheme).not.toHaveBeenCalled()
     expect(result).toBe(false)
+  })
+})
+
+describe("willCommandApply", () => {
+  it("accepts every v1 command except theme with bad args", () => {
+    const theme = findCommand("theme", COMMAND_REGISTRY)
+
+    expect(willCommandApply(findCommand("help", COMMAND_REGISTRY), "")).toBe(true)
+    expect(willCommandApply(theme, "dracula")).toBe(true)
+    expect(willCommandApply(theme, "not-a-real-theme")).toBe(false)
   })
 })

--- a/spec/system/keyboard_nav_command_mode_spec.rb
+++ b/spec/system/keyboard_nav_command_mode_spec.rb
@@ -171,6 +171,26 @@ RSpec.describe "Keyboard navigation -- COMMAND mode (:)", :js do
     expect(page).to have_selector("dialog#keyboard-guide-dialog[open]")
   end
 
+  # :help opens the guide via showModal() after COMMAND mode exits; Esc-closing the
+  # dialog must restore the focus target from before `:` was pressed, not the hidden
+  # command input (issue #1196).
+  it "returns focus to the pre-COMMAND target after Escape-closing the :help guide dialog" do # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+    visit root_path
+    wait_for_keyboard_nav_connected
+    page.evaluate_script('document.querySelector("[data-nav-target=\"projects\"]").focus()')
+
+    press(":")
+    fill_in "Command", with: "help"
+    find("#keyboard-command-input").send_keys(:enter)
+
+    expect(page).to have_selector("dialog#keyboard-guide-dialog[open]")
+
+    press(:escape)
+
+    expect(page).to have_no_selector("dialog#keyboard-guide-dialog[open]")
+    expect(page).to have_selector("[data-nav-target='projects']:focus")
+  end
+
   it "live-filters matching command names into the feedback row as the visitor types" do
     visit root_path
     wait_for_keyboard_nav_connected


### PR DESCRIPTION
## Summary
- Reorders `commitCommand()` so `exitToNormal()` (blur + prior-focus restore) runs before `command.run()`, fixing Escape-close on the `:help` guide dialog refocusing the hidden command input instead of the pre-COMMAND target
- Adds `willCommandApply()` so `:theme` with bad args still keeps the bar open (same R6 not-found behavior)
- Regression system spec + unit tests for the new helper

## Test plan
- [x] `yarn test:js app/javascript/keyboard_nav/commands.test.js` — 31 passing
- [x] `bundle exec rspec spec/system/keyboard_nav_command_mode_spec.rb` — 15 passing (includes new Escape refocus example)
- [ ] CI green

Closes #1196

Made with [Cursor](https://cursor.com)