### PR TITLE
[#1193] Fix nord text-primary WCAG AA contrast on base-100

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -6,8 +6,12 @@
  * - light/dark: DaisyUI's stock palettes, with base/primary/accent repointed below (see
  *   "Amber accent" and "Dark theme base tokens") to the site's near-black-canvas +
  *   single-amber-accent direction.
- * - dracula/nord: DaisyUI 5 built-in themes, used unmodified -- their own iconic colors
- *   are the point of including them (do not repoint primary/accent to amber).
+ * - dracula: DaisyUI 5 built-in theme, used unmodified -- its own iconic colors
+ *   are the point of including it (do not repoint primary/accent to amber).
+ * - nord: DaisyUI 5 built-in theme, iconic cool-blue hue preserved, but primary and
+ *   primary-content are overridden below (see "Nord primary WCAG AA fix") because the
+ *   stock primary (L≈59%) measures only ~3.5:1 against nord's very light base-100 when
+ *   used as foreground text (`text-primary`), below the 4.5:1 WCAG AA floor (#1193).
  * - gruvbox/catppuccin: not built into DaisyUI 5; defined as custom themes below.
  */
 @plugin "daisyui" {
@@ -233,6 +237,21 @@
   --color-primary-content: #fff7ea;
   --color-accent: #8a5a10;
   --color-accent-content: #fff7ea;
+}
+
+/*
+ * Nord primary WCAG AA fix (#1193): nord's stock `--color-primary` (oklch 59.435% 0.077
+ * 254.027) measures ~3.5:1 against the very light nord base-100 (oklch 95.127% 0.007
+ * 260.731), below the 4.5:1 WCAG AA gate for foreground text (`text-primary`, e.g.
+ * section-eyebrow/hero-eyebrow). Darkening primary to L=50% raises the text ratio to
+ * ~5.2:1; flipping primary-content to near-white (L=95%) keeps the button-face pair
+ * (primary-content on primary) at ~5.2:1. Hue 254.027 and chroma 0.077 are preserved
+ * so nord's iconic cool-blue character is unchanged.
+ * This rule is unlayered (outside @layer) so it wins over DaisyUI's stock layered rule.
+ */
+[data-theme="nord"] {
+  --color-primary: oklch(50% 0.077 254.027);
+  --color-primary-content: oklch(95% 0.010 254.027);
 }
 
 /*

--- a/spec/lib/contrast_spec.rb
+++ b/spec/lib/contrast_spec.rb
@@ -153,6 +153,22 @@ RSpec.describe 'WCAG AA contrast regression gate' do # rubocop:disable RSpec/Des
     end
   end
 
+  # ---- 1193's regression gate: primary as foreground text on base-100 -----------------
+  #
+  # #1193 found that nord's `--color-primary` used as foreground text on `base-100` (the
+  # `text-primary` utility, e.g. section-eyebrow/hero-eyebrow slot) measures ~3.5:1, below
+  # WCAG AA 4.5:1. The gate above only asserts primary-content-on-primary (the button-face
+  # pair) -- it never checked `primary` as a *text color* painted on the page background.
+  # This closes that gap across all six bundled themes.
+  #
+  # Regression: #1193
+  %w[light dark dracula nord gruvbox catppuccin].each do |theme|
+    it "meets WCAG AA 4.5:1 for primary (foreground text) on base-100 in the #{theme} theme (#1193)" do
+      colors = colors_for(theme)
+      expect(contrast_ratio(colors['primary'], colors['base-100'])).to be >= 4.5
+    end
+  end
+
   # ---- 1181's opacity-modified subhead/date token: base-content/70 on base-100 -----------
   #
   # 1181 R1 introduces `text-base-content/70` (hero subhead; also the home card date line, R4)
@@ -163,10 +179,9 @@ RSpec.describe 'WCAG AA contrast regression gate' do # rubocop:disable RSpec/Des
   # gamma-encoded sRGB values `parse_color` returns, matching how browsers composite a
   # partially-transparent solid color, not a linear-light blend).
   #
-  # Deliberately out of scope: the pre-existing nord `text-primary`-on-base-100 gap flagged in
-  # 8cd4343's commit message (measures ~3.5:1) is a separate, pre-existing P1.1 token issue
-  # (the section-eyebrow/hero-eyebrow slot), not the token this issue's subhead/date line
-  # actually uses -- not fixed or asserted here, per that commit's own note.
+  # Note: the pre-existing nord `text-primary`-on-base-100 gap (section-eyebrow/hero-eyebrow
+  # slot, ~3.5:1) that 8cd4343's commit message flagged as out-of-scope for #1181 is now
+  # gated in the section immediately above (Regression: #1193).
   def blend_over(foreground, background, alpha)
     parse_color(foreground).zip(parse_color(background)).map { |fg, bg| (fg * alpha) + (bg * (1 - alpha)) }
   end


### PR DESCRIPTION
## Summary
- Darkens nord `--color-primary` (same hue/chroma) so `text-primary` on `base-100` clears WCAG AA 4.5:1 (~3.5:1 → ~5.2:1)
- Flips `--color-primary-content` to near-white so button-face contrast stays ≥ 4.5:1
- Extends `spec/lib/contrast_spec.rb` to gate primary-as-foreground on base-100 across all six themes

## Test plan
- [x] `bundle exec rspec spec/lib/contrast_spec.rb` — 50 examples, 0 failures
- [ ] Visual spot-check: nord theme section/hero eyebrows still read as nord blue
- [ ] CI green

Closes #1193

Made with [Cursor](https://cursor.com)