### PR TITLE
[#1191] Build-in-public: /changelog page + footer site version

### DIFF
--- a/app/controllers/changelog_controller.rb
+++ b/app/controllers/changelog_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangelogController < ApplicationController # rubocop:disable Style/Documentation
+  def index
+    @releases = Changelog.releases
+  end
+end

--- a/app/models/changelog.rb
+++ b/app/models/changelog.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Single source of truth for the site's build-in-public changelog (#1191): loads
+# db/changelog.yml (an ordered, newest-first list of releases) and exposes it both to the
+# `/changelog` page (Changelog.releases) and to the footer's site version
+# (Changelog.current_version) -- one parse, two call sites, so the two can never drift apart.
+#
+# A plain PORO, not an ActiveRecord model: a changelog is static, owner-edited, in-repo
+# content (like the blog markdown files in db/seeds.rb), not row data -- no table, no
+# migration.
+class Changelog
+  SOURCE_FILE = Rails.root.join("db/changelog.yml")
+
+  # One release entry. `date` is a Date, `changes` an array of strings (inline markdown
+  # allowed -- render through BlogHelper#render_markdown at the view layer, same pipeline
+  # as everywhere else on the site).
+  Release = Struct.new(:version, :date, :title, :changes, keyword_init: true)
+
+  class << self
+    # Ordered releases, newest first. Order is *trusted from the file* (db/changelog.yml
+    # is hand-curated, newest entry on top) rather than re-sorted here -- there's no
+    # re-sort to guarantee semver ordering, so a misordered file renders misordered
+    # rather than silently "fixing" itself. Memoized; call .reset! (tests only) to
+    # force a re-read.
+    def releases
+      @releases ||= load_releases
+    end
+
+    # The newest release (the top of the file), or nil if the file is missing/malformed
+    # or has no entries.
+    def current
+      releases.first
+    end
+
+    # The newest release's version string, or nil in the same degraded cases as .current
+    # -- the footer omits the version entirely rather than rendering a bare "v".
+    def current_version
+      current&.version
+    end
+
+    # Test-only escape hatch so specs can reset memoization between examples that swap
+    # out SOURCE_FILE's contents or exercise the malformed/missing-file path.
+    def reset!
+      @releases = nil
+    end
+
+    private
+
+    def load_releases
+      raw = YAML.safe_load_file(SOURCE_FILE, permitted_classes: [Date])
+      raise TypeError, "expected an Array, got #{raw.class}" unless raw.is_a?(Array)
+
+      raw.map { |entry| Release.new(**entry.symbolize_keys) }
+    rescue StandardError => e
+      # A missing or malformed changelog must never 500 the whole site -- the footer
+      # renders Changelog.current_version on every Home request. Degrade to an empty
+      # list (current/current_version become nil) and log loudly instead.
+      Rails.logger.warn("Changelog failed to load #{SOURCE_FILE}: #{e.class}: #{e.message}")
+      []
+    end
+  end
+end

--- a/app/views/changelog/index.html.erb
+++ b/app/views/changelog/index.html.erb
@@ -1,0 +1,43 @@
+<%
+  set_meta_tags(
+    title: "Changelog",
+    description: "What's shipped on jamesebentier.com, release by release — built in public.",
+  )
+%>
+
+<%# Terminal-identity redesign (#1226) style, matching about/privacy's narrow reading
+    column and mono eyebrow/headings. Content is entirely sourced from Changelog.releases
+    (db/changelog.yml via app/models/changelog.rb) -- the same object the footer's site
+    version (Changelog.current_version) reads, so the two can never drift apart (#1191). %>
+<div class="max-w-[760px] mx-auto px-8 pt-16 pb-20">
+  <p class="font-mono text-sm text-primary mb-3">james@ebentier:~$ cat CHANGELOG.md</p>
+  <h1 class="font-mono text-[34px] leading-[1.25] font-bold mb-4">Changelog</h1>
+  <p class="text-xl text-base-content/70 mb-14">
+    Built in public. Every notable change to this site, newest first.
+  </p>
+
+  <% if @releases.empty? %>
+    <%# Graceful-degradation counterpart to Changelog's load failure (missing/malformed
+        db/changelog.yml) -- render an empty state rather than 500 or a blank page. %>
+    <p class="text-base-content/70">No releases yet — check back soon.</p>
+  <% else %>
+    <div class="flex flex-col gap-12">
+      <% @releases.each do |release| %>
+        <div>
+          <h2 class="flex items-baseline gap-3 mb-2">
+            <span class="font-mono text-[15px] font-bold text-primary">v<%= release.version %></span>
+            <span class="font-mono text-sm text-base-content/50"><%= release.date.strftime("%B %-d, %Y") %></span>
+          </h2>
+          <h3 class="font-mono text-xl font-bold mb-3"><%= release.title %></h3>
+          <%# One render_markdown call per release, over a markdown-list built from
+              `changes` -- reuses the existing Redcarpet pipeline for both the list
+              structure and any inline markdown within an entry, rather than hand-rolling
+              a second (item-by-item) markdown path. %>
+          <div class="prose prose-base max-w-none text-base-content/80">
+            <%= render_markdown(release.changes.map { |change| "- #{change}" }.join("\n")) %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/layouts/components/_footer.html.erb
+++ b/app/views/layouts/components/_footer.html.erb
@@ -8,6 +8,13 @@
     <div>
       <p class="text-[15px] font-bold mb-2.5">
         <span class="text-primary" aria-hidden="true">❯</span> james@ebentier
+        <%# Build-in-public site version (#1191): sourced from Changelog.current_version
+            (db/changelog.yml via app/models/changelog.rb) -- the same object the
+            /changelog page renders, so the two can never drift apart. Omitted entirely
+            (rather than a bare "v") if Changelog degrades to no releases. %>
+        <% if Changelog.current_version.present? %>
+          <%= link_to "v#{Changelog.current_version}", changelog_path, class: "text-primary hover:text-primary/70" %>
+        <% end %>
       </p>
       <p class="text-[13px] text-base-content/50 mb-4">
         &copy; <%= Date.today.year %> James Ebentier &middot; Berlin<br>
@@ -30,6 +37,7 @@
       <div class="flex flex-col gap-2">
         <%= link_to "/writing", posts_url, class: "text-base-content/70 hover:text-primary no-underline" %>
         <%= link_to "/projects", projects_url, class: "text-base-content/70 hover:text-primary no-underline" %>
+        <%= link_to "/changelog", changelog_path, class: "text-base-content/70 hover:text-primary no-underline" %>
         <%= link_to "/about", about_path, class: "text-base-content/70 hover:text-primary no-underline" %>
         <%= link_to "/resume", resume_path, class: "text-base-content/70 hover:text-primary no-underline" %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get "writing/:slug"  => "writing#show",     as: :post
   get "projects"       => "projects#index",   as: :projects
   get "projects/:slug" => "projects#show",    as: :project
+  get "changelog"      => "changelog#index",  as: :changelog
   get "about"          => "welcome#about",    as: :about
   get "resume"         => "welcome#resume",   as: :resume
   get "privacy"        => "welcome#privacy",  as: :privacy

--- a/db/changelog.yml
+++ b/db/changelog.yml
@@ -1,0 +1,32 @@
+# Build-in-public changelog (#1191) — the single source of truth for both the `/changelog`
+# page and the site version shown in the footer (`Changelog.current_version`). Newest
+# release first; the top entry *is* the site version. See `app/models/changelog.rb`.
+#
+# Each entry: version (semver string), date (a Date), title, changes (list of short,
+# visitor-facing strings — inline markdown allowed, rendered via BlogHelper#render_markdown).
+- version: "1.3.0"
+  date: 2026-07-22
+  title: "Build-in-public: this changelog"
+  changes:
+    - "Added this `/changelog` page, listing every notable release."
+    - "The site version now shows in the footer, linked back here — both read from the
+      same source, so they can never drift apart."
+- version: "1.2.0"
+  date: 2026-07-21
+  title: "Legal pages"
+  changes:
+    - "Added an Impressum and a GDPR-compliant privacy policy, linked from the footer."
+- version: "1.1.0"
+  date: 2026-07-20
+  title: "First-party analytics"
+  changes:
+    - "Replaced Google Analytics and Metricool with cookieless, first-party analytics —
+      no third-party trackers, no cookies, no per-visitor IDs."
+- version: "1.0.0"
+  date: 2026-07-19
+  title: "Terminal-identity redesign"
+  changes:
+    - "Redesigned the whole site around a terminal metaphor — modal keyboard navigation,
+      monospace type, a statusline, across all six pages."
+    - "Added newsletter signup with double opt-in, so subscribing is explicit and
+      confirmed before any mail goes out."

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -73,6 +73,7 @@ Every non-test file under `app/` and `lib/` appears here exactly once. Reviewers
 ### content-domain
 
 - `app/models/application_record.rb` — ActiveRecord base; model-level `noindex?` for sitemap
+- `app/models/changelog.rb` — `Changelog` PORO: loads `db/changelog.yml` (no table/migration) into `Changelog::Release` value objects; single source for `/changelog` and the footer's `Changelog.current_version`
 - `app/models/post.rb` — Blog post metadata + markdown file content loader
 - `app/models/project.rb` — Project portfolio record + optional markdown detail loader
 - `app/models/subscriber.rb` — Newsletter subscriber: double opt-in lifecycle (pending/confirmed/unsubscribed), consent metadata, one-way IP hash
@@ -84,6 +85,7 @@ Every non-test file under `app/` and `lib/` appears here exactly once. Reviewers
 
 ### web-presentation
 
+- `app/controllers/changelog_controller.rb` — Changelog index (`Changelog.releases`, #1191)
 - `app/controllers/projects_controller.rb` — Projects index/show
 - `app/controllers/welcome_controller.rb` — Landing + resume + impressum + privacy
 - `app/controllers/writing_controller.rb` — Writing (Notes/Deep Dives) index/show
@@ -113,6 +115,7 @@ Every non-test file under `app/` and `lib/` appears here exactly once. Reviewers
 - `app/assets/images/.keep` — Images keepfile
 - `app/assets/images/landing-image.webp` — Landing hero image
 - `app/assets/stylesheets/application.tailwind.css` — Tailwind entry CSS + `@theme` tokens/DaisyUI theme source of truth
+- `app/views/changelog/index.html.erb` — Changelog listing (`Changelog.releases`, terminal-identity style, #1191)
 - `app/views/components/_card.html.erb` — Shared card partial (stretched-link wrapper, hover-lift)
 - `app/views/components/_cta_button.html.erb` — Shared CTA button partial (primary/ghost)
 - `app/views/components/_newsletter_signup.html.erb` — Newsletter signup form partial (email + consent checkbox; source: local)
@@ -121,7 +124,7 @@ Every non-test file under `app/` and `lib/` appears here exactly once. Reviewers
 - `app/views/components/_work_with_me_cta.html.erb` — Shared "Work with me" mailto CTA block (home/about)
 - `app/views/layouts/application.html.erb` — Main HTML layout (meta-tags, analytics, FOUC-prevention theme script)
 - `app/views/layouts/components/_header.html.erb` — Site header
-- `app/views/layouts/components/_footer.html.erb` — Home-only site footer (identity/sitemap/newsletter)
+- `app/views/layouts/components/_footer.html.erb` — Home-only site footer (identity/sitemap/newsletter); identity line links `Changelog.current_version` to `/changelog` (#1191)
 - `app/views/layouts/mailer.html.erb` — HTML mailer layout
 - `app/views/layouts/mailer.text.erb` — Text mailer layout
 - `app/views/projects/index.html.erb` — Projects listing
@@ -167,10 +170,10 @@ Every non-test file under `app/` and `lib/` appears here exactly once. Reviewers
 | Subsystem | File count |
 |-----------|------------|
 | rails-runtime | 6 |
-| content-domain | 5 |
+| content-domain | 6 |
 | markdown-rendering | 1 |
-| web-presentation | 59 |
+| web-presentation | 63 |
 | keyboard-navigation | 11 |
-| **Total** | **82** |
+| **Total** | **87** |
 
 Must equal `git ls-files app lib | grep -v '\.test\.js$' | wc -l`.

--- a/docs/design/2026-07-22-changelog-site-version-design.md
+++ b/docs/design/2026-07-22-changelog-site-version-design.md
@@ -1,0 +1,89 @@
+# P1.12 — Build-in-public: /changelog + site version (#1191)
+
+## Problem
+
+The refresh should be documented publicly. Two code deliverables (the companion
+"Rebuilding this site" Notes series is separate editorial via P1.4, out of scope here):
+
+1. A **`/changelog`** page listing the site's notable changes over time.
+2. A **site version** shown in the footer.
+
+The site has **no version source today** — `package.json` has no `version`, there are no
+git tags, no `VERSION` file. So this issue must establish one. The changelog page and the
+footer version are the same information at two altitudes (the footer shows the newest
+release; the page shows the history), so they must derive from **one source of truth** — a
+footer version that can drift from the changelog is exactly the bug to avoid.
+
+## Chosen approach
+
+**One structured data file is the single source of truth**, read by a small plain-Ruby
+`Changelog` domain object — no database table, no migration. A changelog is static,
+in-repo, owner-edited content; a DB model (like `Post`) is the wrong altitude for it.
+
+- **Source file:** `db/changelog.yml` — an ordered list of releases, newest first:
+  ```yaml
+  - version: "1.1.0"
+    date: 2026-07-22
+    title: "Legal pages"
+    changes:
+      - "Impressum + GDPR-compliant privacy policy, linked from the footer."
+  - version: "1.0.0"
+    date: 2026-07-DD
+    title: "Terminal-identity redesign"
+    changes:
+      - "Full redesign across all six pages."
+      - "First-party, cookieless analytics replacing Google Analytics + Metricool."
+  ```
+  YAML (not one-markdown-file-per-release) because a changelog is a *list of short dated
+  entries*, and a single file keeps the whole history reviewable in one diff. Each
+  free-text field may contain inline markdown, rendered through the **existing
+  `BlogHelper#render_markdown`** so we reuse the site's Redcarpet pipeline (satisfies the
+  P1.4 soft-dependency) without inventing a second content system.
+
+- **Domain object:** `Changelog` (a PORO, `app/models/changelog.rb`) that loads and
+  validates the YAML into `Changelog::Release` value objects, exposes `Changelog.releases`
+  (ordered) and `Changelog.current` / `Changelog.current_version` (the newest release).
+  Reads the file once and memoizes.
+
+- **Route + page:** `get "changelog" => "changelog#index"` → a dedicated
+  `ChangelogController#index` (matches the `projects`/`writing` content-index-controller
+  convention rather than piling onto `welcome`). View `app/views/changelog/index.html.erb`
+  in the established terminal-identity page style (like `about`/`privacy`): a
+  `cat CHANGELOG.md`-style eyebrow, mono headings, each release rendered with its version,
+  date, title, and change list.
+
+- **Footer version:** the existing copyright block in
+  `app/views/layouts/components/_footer.html.erb` gains `v#{Changelog.current_version}`,
+  linked to `/changelog`. One helper call, sourced from the same object as the page.
+
+**Versioning policy:** human-curated semver in the changelog file, owner-bumped per notable
+change — not derived from git. The newest entry *is* the site version. Seeding the initial
+file with a couple of real past milestones (redesign, analytics, legal) gives the page
+non-empty content on day one.
+
+No new gems (Redcarpet + YAML already present), no migration, no JS.
+
+## Acceptance criteria
+
+- `GET /changelog` returns 200 and renders each release from `db/changelog.yml` (version,
+  date, title, changes), in newest-first order, with inline markdown rendered.
+- The footer shows `v<current version>` on every page that renders the footer, linked to
+  `/changelog`, and the value equals the newest release in `db/changelog.yml` (proving the
+  single source of truth).
+- Adding a new entry at the top of `db/changelog.yml` updates **both** the page and the
+  footer version with no other code change.
+- `Changelog` handles a malformed/missing file without 500-ing the whole site footer
+  (degrade gracefully — e.g. blank/omitted version rather than crashing every page).
+- Specs cover: the domain object (ordering, `current_version`, graceful degradation), the
+  `/changelog` request (200 + content), and the footer version rendering + link.
+
+## Open questions
+
+1. **Changelog scope/voice** — build-in-public, visitor-facing prose (what shipped and why),
+   *not* a raw commit log. I'll seed 2–3 real past milestones; **owner supplies/edits the
+   exact copy and the starting version number** (defaulting to `1.0.0` = the redesign,
+   `1.1.0` = legal, or a scheme you prefer). Confirm the version scheme.
+2. **Footer placement** — `v1.1.0` sits next to the `© 2026 · Berlin` / `Impressum · Privacy`
+   line. OK, or do you want it elsewhere (e.g. the `❯ james@ebentier` prompt line)?
+3. **File location** — `db/changelog.yml` (alongside seeds/data) vs `config/changelog.yml`
+   vs a root `CHANGELOG.md`. I lean `db/changelog.yml`. Object if you'd rather it live elsewhere.

--- a/spec/models/changelog_spec.rb
+++ b/spec/models/changelog_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "tempfile"
+
+# Changelog (#1191) is a plain PORO -- no table -- so these specs exercise the real
+# db/changelog.yml (the actual single source of truth for both the /changelog page and
+# the footer's site version) plus two swapped-out fixture files for the ordering-trust and
+# graceful-degradation guarantees the class' comments promise. Changelog.reset! is called
+# around every example that touches SOURCE_FILE so memoization never leaks the real data
+# into a fixture example, or a fixture's data into a later spec file (see the top-level
+# `after`).
+RSpec.describe Changelog do
+  after { described_class.reset! }
+
+  describe ".releases" do
+    it "returns the real db/changelog.yml releases newest-first, in file order" do
+      described_class.reset!
+
+      expect(described_class.releases.map(&:version)).to eq(%w[1.3.0 1.2.0 1.1.0 1.0.0])
+    end
+
+    it "parses each entry into a Release with the right version/date/title/changes" do # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
+      described_class.reset!
+
+      release = described_class.releases.first
+
+      expect(release).to have_attributes(
+        version: "1.3.0",
+        date: Date.new(2026, 7, 22),
+        title: "Build-in-public: this changelog"
+      )
+      expect(release.changes).to be_an(Array).and be_present
+    end
+
+    it "trusts the file's order rather than re-sorting by semver" do # rubocop:disable RSpec/ExampleLength
+      out_of_order_yaml = <<~YAML
+        - version: "0.1.0"
+          date: 2026-01-01
+          title: "Old release, listed first"
+          changes:
+            - "first"
+        - version: "9.9.9"
+          date: 2026-02-01
+          title: "Newer release, listed second"
+          changes:
+            - "second"
+      YAML
+
+      with_changelog_fixture(out_of_order_yaml) do
+        expect(described_class.releases.map(&:version)).to eq(%w[0.1.0 9.9.9])
+      end
+    end
+  end
+
+  describe ".current and .current_version" do
+    it "returns the newest (topmost) release from .current" do
+      described_class.reset!
+
+      expect(described_class.current.version).to eq("1.3.0")
+    end
+
+    it "returns the newest release's version string from .current_version" do
+      described_class.reset!
+
+      expect(described_class.current_version).to eq("1.3.0")
+    end
+  end
+
+  describe "graceful degradation" do
+    it "returns no releases and a nil current_version when the source file is missing, without raising" do # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
+      stub_const("Changelog::SOURCE_FILE", Rails.root.join("db/does-not-exist-#{SecureRandom.hex(4)}.yml"))
+      described_class.reset!
+
+      expect { described_class.releases }.not_to raise_error
+      expect(described_class.releases).to eq([])
+      expect(described_class.current).to be_nil
+      expect(described_class.current_version).to be_nil
+    end
+
+    it "returns no releases and a nil current_version when the source file is malformed YAML, without raising" do # rubocop:disable RSpec/MultipleExpectations
+      with_changelog_fixture("not: valid: yaml: [") do
+        expect { described_class.releases }.not_to raise_error
+        expect(described_class.releases).to eq([])
+        expect(described_class.current_version).to be_nil
+      end
+    end
+
+    it "returns no releases when the file parses but is not an Array" do
+      with_changelog_fixture("just_a_top_level_string") do
+        expect(described_class.releases).to eq([])
+      end
+    end
+  end
+
+  # Writes `contents` to a real temp file, points Changelog::SOURCE_FILE at it for the
+  # duration of the block, and forces a fresh parse before and after -- the least-hacky hook
+  # the class exposes (it always reads from the SOURCE_FILE constant; there is no
+  # dependency-injection seam beyond that).
+  def with_changelog_fixture(contents)
+    Tempfile.create(["changelog", ".yml"]) do |file|
+      file.write(contents)
+      file.flush
+
+      stub_const("Changelog::SOURCE_FILE", Pathname.new(file.path))
+      described_class.reset!
+
+      yield
+    end
+  ensure
+    described_class.reset!
+  end
+end

--- a/spec/requests/changelog_spec.rb
+++ b/spec/requests/changelog_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Changelog (#1191)" do
+  describe "GET /changelog" do
+    it "returns a successful response" do
+      get changelog_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the changelog page's terminal eyebrow and heading, not just any 200" do # rubocop:disable RSpec/MultipleExpectations
+      get changelog_path
+
+      expect(response.body).to include("cat CHANGELOG.md")
+      expect(response.parsed_body.at_css("h1").text).to eq("Changelog")
+    end
+
+    it "renders the current version, sourced from db/changelog.yml via Changelog.current_version" do
+      get changelog_path
+
+      expect(response.body).to include("v#{Changelog.current_version}")
+    end
+
+    it "renders the newest release's title" do
+      get changelog_path
+
+      expect(response.body).to include(Changelog.current.title)
+    end
+
+    it "renders the newest release's date" do
+      get changelog_path
+
+      expect(response.body).to include(Changelog.current.date.strftime("%B %-d, %Y"))
+    end
+
+    it "renders at least one change line from the newest release, through the markdown pipeline" do
+      get changelog_path
+
+      # `changes` are rendered as a markdown list via BlogHelper#render_markdown -- assert
+      # on the parsed text (not raw response.body) so an inline-markdown change entry
+      # (e.g. a `code span`) doesn't break the match on its surrounding tag structure.
+      expect(response.parsed_body.text).to include(Changelog.current.changes.first.gsub(/[`*_]/, ""))
+    end
+
+    it "lists every real release's version, not just the newest" do
+      get changelog_path
+
+      versions = Changelog.releases.map(&:version)
+
+      expect(versions).to all(satisfy { |v| response.body.include?("v#{v}") })
+    end
+  end
+end

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -367,4 +367,29 @@ RSpec.describe "Welcomes" do
       expect(footer_link.text).to eq("Privacy")
     end
   end
+
+  # Build-in-public site version (#1191): the footer's "james@ebentier" prompt line links a
+  # "v<version>" tag to /changelog, sourced from Changelog.current_version -- the very same
+  # object the /changelog page itself renders (see spec/models/changelog_spec.rb and
+  # spec/requests/changelog_spec.rb). Deriving the expected text from Changelog.current_version
+  # here, rather than hardcoding "v1.3.0", is the point: it proves the footer and the model
+  # can't drift apart, not just that today's fixture happens to match.
+  describe "GET / — footer site version (#1191)" do
+    it "shows the current site version, linked to /changelog, on the james@ebentier prompt line" do # rubocop:disable RSpec/MultipleExpectations
+      get root_path
+
+      version_link = response.parsed_body.css("footer a[href='#{changelog_path}']").find { |a| a.text.start_with?("v") }
+
+      expect(version_link).to be_present
+      expect(version_link.text).to eq("v#{Changelog.current_version}")
+    end
+
+    it "links the footer sitemap's /changelog entry to the changelog page" do
+      get root_path
+
+      sitemap_link = response.parsed_body.css("footer a[href='#{changelog_path}']").find { |a| a.text == "/changelog" }
+
+      expect(sitemap_link).to be_present
+    end
+  end
 end


### PR DESCRIPTION
Closes #1191

## What

P1.12 — document the refresh publicly.

- **`/changelog`** page listing releases in the terminal-identity style, each with version, date, title, and change notes (rendered through the existing `BlogHelper#render_markdown` — the site's single markdown pipeline).
- **Site version in the footer** — `v<current>` on the `❯ james@ebentier` prompt line, linked to `/changelog`.

### Single source of truth
Both the page and the footer version derive from **one file**, `db/changelog.yml`, via a small `Changelog` PORO (no DB table, no migration). Add an entry at the top of the YAML → both the page and the footer version update, nothing else. A missing/malformed file degrades gracefully (version omitted) instead of 500-ing the footer on every page.

Seeded with real milestones (`1.0.0` redesign → `1.3.0` this changelog) as a build-in-public draft — **owner edits the copy/dates/versions in `db/changelog.yml`**.

## Tests

- `Changelog` model: file-order (no re-sort), `current_version`, and graceful degradation on missing/malformed/non-array YAML (asserted not to raise).
- `GET /changelog` → 200 + real content (current version, titles, change lines).
- Footer shows `v<Changelog.current_version>` linked to `changelog_path` (derived from the model, not hard-coded — proves the single-source wiring) + `/changelog` sitemap link.
- Full suite: 602 passed, 2 pre-existing pending. No regressions.

## Owner follow-up
Tune the changelog copy/dates and the version scheme in `db/changelog.yml` to taste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)