### PR TITLE
Writing: stack the mobile post list so titles lead

### DIFF
--- a/app/views/writing/index.html.erb
+++ b/app/views/writing/index.html.erb
@@ -32,15 +32,36 @@
 
   <div class="border-t border-base-300">
     <% posts.each do |post| %>
-      <%= link_to post_url(slug: post.slug), class: "flex items-baseline gap-4 py-3.5 px-2 border-b border-base-300 no-underline hover:bg-base-200" do %>
-        <span class="w-[100px] shrink-0 text-[13px] text-base-content/50"><%= post.published_at.strftime("%Y-%m-%d") %></span>
-        <span class="shrink-0 text-[13px] text-primary" aria-hidden="true"><%= post.kind_glyph %></span>
-        <span class="sr-only"><%= post.kind_label %></span>
-        <span class="flex-1 text-base font-bold min-w-0 truncate hover:text-primary"><%= post.title %></span>
-        <% if post.tags.first.present? %>
-          <span class="shrink-0 text-xs text-base-content/50 whitespace-nowrap">#<%= post.tags.first %></span>
-        <% end %>
-        <span class="w-14 shrink-0 text-right text-[13px] text-base-content/50"><%= post.reading_time %> min</span>
+      <%= link_to post_url(slug: post.slug), class: "block border-b border-base-300 no-underline hover:bg-base-200 group" do %>
+        <%# Desktop (>=sm): single-line `ls` directory listing. %>
+        <span class="hidden sm:flex items-baseline gap-4 py-3.5 px-2">
+          <span class="w-[100px] shrink-0 text-[13px] text-base-content/50"><%= post.published_at.strftime("%Y-%m-%d") %></span>
+          <span class="shrink-0 text-[13px] text-primary" aria-hidden="true"><%= post.kind_glyph %></span>
+          <span class="sr-only"><%= post.kind_label %></span>
+          <span class="flex-1 text-base font-bold min-w-0 truncate group-hover:text-primary"><%= post.title %></span>
+          <% if post.tags.first.present? %>
+            <span class="shrink-0 text-xs text-base-content/50 whitespace-nowrap">#<%= post.tags.first %></span>
+          <% end %>
+          <span class="w-14 shrink-0 text-right text-[13px] text-base-content/50"><%= post.reading_time %> min</span>
+        </span>
+
+        <%# Mobile (<sm): stack so the title leads at full width, metadata drops below. %>
+        <span class="flex sm:hidden gap-2.5 py-3.5 px-2">
+          <span class="shrink-0 text-sm text-primary leading-6" aria-hidden="true"><%= post.kind_glyph %></span>
+          <span class="sr-only"><%= post.kind_label %></span>
+          <span class="min-w-0 flex-1">
+            <span class="block text-base font-bold leading-snug break-words group-hover:text-primary"><%= post.title %></span>
+            <span class="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-base-content/50">
+              <span><%= post.published_at.strftime("%Y-%m-%d") %></span>
+              <% if post.tags.first.present? %>
+                <span aria-hidden="true">&middot;</span>
+                <span class="text-base-content/70">#<%= post.tags.first %></span>
+              <% end %>
+              <span aria-hidden="true">&middot;</span>
+              <span><%= post.reading_time %> min</span>
+            </span>
+          </span>
+        </span>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
## Problem

On the `/writing` index, each row is a single flexbox line: a fixed 100px date column, the kind glyph, the title, the `#tag`, and `N min` all competing for width. On a phone that collapses the **title** — the one thing a reader scans for — to 2–3 characters (`Ri…`, `AI…`, `Je…`), while the date/tag/read-time still overflow off the right edge.

## Change

`app/views/writing/index.html.erb` — split the row into two layouts that swap at Tailwind's `sm` (640px) breakpoint:

- **≥ 640px** — the existing single-line `ls` directory listing, unchanged (`date · ◇ · title · #tag · N min`).
- **< 640px** — the title leads at full width and wraps (`break-words`, so long tokens never clip); the kind glyph sits to its left as a marker; the metadata drops to a quiet second line: `2026-07-23 · #research · 3 min`.

Other notes:
- The `sr-only` kind label rides along in both variants, and the hidden variant is `display:none` — so only the visible layout ever reaches the accessibility tree (no double announcement).
- Title hover-highlight moved to `group-hover`, so hovering anywhere on the row lights the title in both layouts.
- View-only change; no controller/model/JS touched. Server-rendered kind filter is untouched.

## Verification

Rendered the real page markup against the freshly-built Tailwind CSS with real post data at both breakpoints:

- **Mobile before:** titles truncated to ~10 chars.
- **Mobile after:** full titles wrap to two lines, clean meta line beneath, no clipping.
- **Desktop after:** single-line `ls` listing unchanged.

Instrumented the layout to confirm `min-w-0` clamps the title column and there is no horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)