### PR TITLE
Publish "The Title Always Said Engineer"

### DIFF
--- a/public/blog/2026-08-23-the-title-always-said-engineer.md
+++ b/public/blog/2026-08-23-the-title-always-said-engineer.md
@@ -1,0 +1,29 @@
+---
+slug: 2026-08-23-the-title-always-said-engineer
+title: "The Title Always Said Engineer"
+description: "Writing code was always a requirement of the job, never the value of it. Engineers architect systems, extract the real ask, shape the first pass, and teach. The mechanical part just stopped eating the day."
+published_at: 2026-08-23
+keywords: "software engineer vs developer, engineering judgment, AI coding, systems thinking, engineering craft, career"
+image: /logo.png
+tags:
+- ai
+- career
+- engineering
+kind: note
+---
+
+# The Title Always Said Engineer
+
+Nobody ever called the role "software coder." The title has *engineer* in it, and I don't think that was an accident.
+
+Writing code was always a requirement of the job. It was never the value of it. Engineers architect, build, and maintain systems; that is what the word means in the disciplines we borrowed it from, and it means the same thing here. Developer and coder name real activities, but they name a part and quietly imply it is the whole. **Coding is something engineers do. It is not the most important thing we do.**
+
+Look at what the job actually asks of us. We see the system, not just the ticket sitting in front of it. We extract the real value out of the ask, because what someone requests and what they need are rarely the same sentence. We shape the best first pass, the one built to iterate and grow instead of calcify. We teach the people around us. We push the practices and the process forward so the next thing costs less than the last one did.
+
+All of that was always in the job description. Almost none of it got the hours it deserved, because the mechanical half ate the day. The typing was never the point. It was just expensive enough to crowd the point out.
+
+That is the part that is changing, and it is why this moment reads to me as exciting rather than threatening. The machine is taking the slow, mechanical half. What it hands back is time, and the things it hands that time back to are precisely the things that were always the job: judgment, design, teaching, taste. [Reasoning from first principles](/writing/2026-08-23-first-principles-in-the-age-of-pattern-machines) is not some new skill we have to go acquire. It is the old one we finally have room to practice.
+
+To be clear about what I am *not* claiming: that time is offered, not granted. Plenty of places will quietly reclaim every freed hour as throughput, and holding those hours for the real work is its own fight. But the hours exist now, and they did not before.
+
+The title always said engineer. We are about to have the time to be one.


### PR DESCRIPTION
Short-form companion note to [First Principles in the Age of Pattern Machines](https://github.com/bitidev/jamesebentier.com/pull/1288), published the same day. Exported from the notes vault via `bin/export-to-site`.

**Thesis:** writing code was always a requirement of the job, never the value of it. The time the machine hands back goes to the work that was always the job: seeing the system, extracting the real ask, shaping a first pass built to iterate, teaching, advancing the practices.

- `kind: note`, `published_at: 2026-08-23`, 372 words
- Tags: ai, career, engineering
- Vault-only sections stripped via `<!-- site:cut -->`
- In-body wikilink resolves to `/writing/2026-08-23-first-principles-in-the-age-of-pattern-machines`

Passed the `blog-editor` gate. Two claims were narrowed during that pass ("software coder" scoped to the compound, "engineer" scoped to the disciplines the word came from) and a not-claiming concession was added noting that freed time is offered rather than granted.

Verified locally with `bin/rails db:seed` (Post record created, 27 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGgwB2r94VNkzAF91H2173